### PR TITLE
Use "wasm32-wasip1" instead of "wasm32-wasi" for UDF

### DIFF
--- a/sql/udfs/use-udfs-in-rust.mdx
+++ b/sql/udfs/use-udfs-in-rust.mdx
@@ -79,9 +79,9 @@ If you want to use other libraries in your Rust functions, you can manually buil
 ### Prerequisites
 
 * Ensure that you have [Rust toolchain](https://rustup.rs) (stable channel) installed on your computer.
-* Ensure that the Rust standard library for `wasm32-wasi` target is installed:
+* Ensure that the Rust standard library for `wasm32-wasip1` target is installed:
 ```sql
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 ### 1\. Create a project
@@ -134,10 +134,10 @@ See the correspondence between SQL types and Rust types in the [Data type mappin
 Build your functions into a WebAssembly module:
 
 ```bash
-cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-wasip1
 ```
 
-You can find the generated WASM module at `target/wasm32-wasi/release/udf.wasm`.
+You can find the generated WASM module at `target/wasm32-wasip1/release/udf.wasm`.
 
 Optional: It is recommended to strip the binary to reduce its size:
 
@@ -146,7 +146,7 @@ Optional: It is recommended to strip the binary to reduce its size:
 cargo install wasm-tools
 
 # Strip the binary
-wasm-tools strip ./target/wasm32-wasi/release/udf.wasm > udf.wasm
+wasm-tools strip ./target/wasm32-wasip1/release/udf.wasm > udf.wasm
 ```
 
 ## 4\. Declare your functions in RisingWave


### PR DESCRIPTION
The target `wasm32-wasi` is removed in latest rust. https://github.com/rust-lang/rust/issues/132640

Also updated in https://github.com/arrow-udf/arrow-udf/pull/81