### PR TITLE
Remove primary key in `ALTER TABLE ADD COLUMN`

### DIFF
--- a/sql/commands/sql-alter-table.mdx
+++ b/sql/commands/sql-alter-table.mdx
@@ -18,7 +18,7 @@ alter_option depends on the operation you want to perform on the table. For all 
 
 ```sql
 ALTER TABLE table_name
-    ADD [ COLUMN ] column_name data_type [ PRIMARY KEY ] [ DEFAULT default_expr ];
+    ADD [ COLUMN ] column_name data_type [ DEFAULT default_expr ];
 ```
 
 | Parameter or clause  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |


### PR DESCRIPTION
## Description

Remove primary key in `ALTER TABLE ADD COLUMN`

## Related Code issue

https://github.com/risingwavelabs/risingwave/issues/19609#issuecomment-2507178540