### PR TITLE
Clarify one-based numbering for arrays

### DIFF
--- a/sql/data-types/array-type.mdx
+++ b/sql/data-types/array-type.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ARRAY type"
-description: "An array `T[]` is an ordered list of zero or more elements that share the same data type. RisingWave uses one-based indexing for arrays, meaning an array with n elements starts at `array[1]` and ends at `array[n]`."
+description: "An array `T[]` is an ordered list of zero or more elements that share the same data type. PostgreSQL uses one-based indexing for arrays, meaning an array with n elements starts at `array[1]` and ends at `array[n]`. RisingWave also applies one-based indexing to align with PostgreSQL."
 ---
 
 ## Define an array

--- a/sql/data-types/array-type.mdx
+++ b/sql/data-types/array-type.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ARRAY type"
-description: "An array `T[]` is an ordered list of zero or more elements that share the same data type."
+description: "An array `T[]` is an ordered list of zero or more elements that share the same data type. RisingWave uses one-based indexing for arrays, meaning an array with n elements starts at `array[1]` and ends at `array[n]`."
 ---
 
 ## Define an array
@@ -46,7 +46,7 @@ CREATE TABLE taxi (
 
 To add values to an array, in the SQL statement, use ARRAY to indicate that this is an array, and then enclose the data in the array with `[]`. For example, `ARRAY ['ABCD1234', 'ABCD1235', 'ABCD1236', 'ABCD1237']`.
 
-#### Examples[](#examples-1 "Direct link to Examples")
+### Examples[](#examples-1 "Direct link to Examples")
 
 Add values to table `x`:
 


### PR DESCRIPTION
## Description
Clarify that RW applies one-based numbering for arrays

## Related doc issue
Resovle https://github.com/risingwavelabs/risingwave-docs/issues/113