### PR TITLE
Document `explain format [text | json]`

### DIFF
--- a/changelog/product-lifecycle.mdx
+++ b/changelog/product-lifecycle.mdx
@@ -22,6 +22,7 @@ Below is a list of all features in the public preview phase:
 
 | Feature name |  Start version |
 | :-- | :-- |
+| [EXPLAIN FORMAT JSON](/sql/commands/sql-explain#explain-options)| 2.2 |
 | [Ingest data from Postgres table](/integrations/sources/postgresql-table) | 2.1 |
 | [Ingest data from webhook](/integrations/sources/webhook) | 2.1 |
 | [Shared source](/sql/commands/sql-create-source#shared-source)  | 2.1  |

--- a/sql/commands/sql-explain.mdx
+++ b/sql/commands/sql-explain.mdx
@@ -23,6 +23,7 @@ EXPLAIN [ ( option [ , ... ] ) ] statement;
 | **VERBOSE** | `[ TRUE \| FALSE ]` | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator. |  
 | **TRACE**  | `[ TRUE \| FALSE ]`   | Show the trace of each optimization stage, not only the final plan.   | 
 | **TYPE** | `[ PHYSICAL \| LOGICAL \| DISTSQL ]`     | Show the execution plan of a specific phase.<ul><li>PHYSICAL — Show the batch plan or stream plan.</li><li>LOGICAL — Show the optimized logical plan.</li><li>DISTSQL — Show the distributed query plan for batch or stream.</li></ul> |
+| **FORMAT** ｜ `[ TEXT \| JSON ]` | <ul><li>For `FORMAT JSON`, the output shows `LOGICAL` and `PHYSICAL` plans in JSON format while ignoring `TRACE` and `DISTSQL` options.</li><li>For `FORMAT TEXT`, the output matches the current output format of `EXPLAIN`.</li></ul> |
 
 <Note>
 The boolean parameter `[ TRUE | FALSE ]` specifies whether the specified option should be enabled or disabled. Use `TRUE` to enable the option, and `FALSE` to disable it. It defaults to `TRUE` if the parameter is not specified.

--- a/sql/commands/sql-explain.mdx
+++ b/sql/commands/sql-explain.mdx
@@ -18,15 +18,22 @@ EXPLAIN [ ( option [ , ... ] ) ] statement;
 
 #### `EXPLAIN` options
 
-| Option       | Supported values | Description     |
-| :----------- | :-------------- | :-------------- |
-| **VERBOSE** | `[ TRUE \| FALSE ]` | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator. |  
-| **TRACE**  | `[ TRUE \| FALSE ]`   | Show the trace of each optimization stage, not only the final plan.   | 
-| **TYPE** | `[ PHYSICAL \| LOGICAL \| DISTSQL ]`     | Show the execution plan of a specific phase.<ul><li>PHYSICAL — Show the batch plan or stream plan.</li><li>LOGICAL — Show the optimized logical plan.</li><li>DISTSQL — Show the distributed query plan for batch or stream.</li></ul> |
-| **FORMAT** ｜ `[ TEXT \| JSON ]` | <ul><li>For `FORMAT JSON`, the output shows `LOGICAL` and `PHYSICAL` plans in JSON format while ignoring `TRACE` and `DISTSQL` options.</li><li>For `FORMAT TEXT`, the output matches the current output format of `EXPLAIN`.</li></ul> |
+| Option       | Supported values                | Description                                                                                                                                                                     |
+| :----------- | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **VERBOSE**  | `[ TRUE \| FALSE ]`             | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator.                                        |
+| **TRACE**    | `[ TRUE \| FALSE ]`             | Show the trace of each optimization stage, not only the final plan.                                                                                                          |
+| **TYPE**     | `[ PHYSICAL \| LOGICAL \| DISTSQL ]` | Show the execution plan of a specific phase.<ul><li>PHYSICAL — Show the batch plan or stream plan.</li><li>LOGICAL — Show the optimized logical plan.</li><li>DISTSQL — Show the distributed query plan for batch or stream.</li></ul> |
+| **FORMAT**    | `[ TEXT \| JSON ]`              | <ul><li>FORMAT JSON - Show the `logical` and `physical` plans in JSON format while ignoring `trace` and `distsql` options.</li><li>FORMAT TEXT - Match the current output format of `EXPLAIN`.</li></ul> |
 
 <Note>
 The boolean parameter `[ TRUE | FALSE ]` specifies whether the specified option should be enabled or disabled. Use `TRUE` to enable the option, and `FALSE` to disable it. It defaults to `TRUE` if the parameter is not specified.
+</Note>
+
+<Note>
+**PUBLIC PREVIEW**
+
+`EXPLAIN FORMAT JSON` is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
+
 </Note>
 
 ## Examples

--- a/sql/commands/sql-explain.mdx
+++ b/sql/commands/sql-explain.mdx
@@ -18,11 +18,11 @@ EXPLAIN [ ( option [ , ... ] ) ] statement;
 
 #### `EXPLAIN` options
 
-| Option                          | Description                                                                                                                            |                                                                                                                                                                                                    |
-| :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **VERBOSE** \[ TRUE \| FALSE \] | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator. |                                                                                                                                                                                                    |
-| **TRACE** \[ TRUE \| FALSE \]   | Show the trace of each optimization stage, not only the final plan.                                                                    |                                                                                                                                                                                                    |
-| **TYPE** \[ PHYSICAL \| LOGICAL | DISTSQL \]                                                                                                                             | Show the execution plan of a specific phase.PHYSICAL — Show the batch plan or stream plan.LOGICAL — Show the optimized logical plan.DISTSQL — Show the distributed query plan for batch or stream. |
+| Option       | Supported values | Description     |
+| :----------- | :-------------- | :-------------- |
+| **VERBOSE** | `[ TRUE \| FALSE ]` | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator. |  
+| **TRACE**  | `[ TRUE \| FALSE ]`   | Show the trace of each optimization stage, not only the final plan.   | 
+| **TYPE** | `[ PHYSICAL \| LOGICAL \| DISTSQL ]`     | Show the execution plan of a specific phase.<ul><li>PHYSICAL — Show the batch plan or stream plan.</li><li>LOGICAL — Show the optimized logical plan.</li><li>DISTSQL — Show the distributed query plan for batch or stream.</li></ul> |
 
 <Note>
 The boolean parameter `[ TRUE | FALSE ]` specifies whether the specified option should be enabled or disabled. Use `TRUE` to enable the option, and `FALSE` to disable it. It defaults to `TRUE` if the parameter is not specified.


### PR DESCRIPTION
## Description

Document `format [text | json]` as new explain options

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/19041

## Related doc issue

Resolve https://github.com/risingwavelabs/risingwave-docs-legacy/issues/2726


