### PR TITLE
fix: add `statistics.interval.ms` to report metrics from kafka

### DIFF
--- a/integrations/destinations/apache-kafka.mdx
+++ b/integrations/destinations/apache-kafka.mdx
@@ -63,9 +63,12 @@ When creating a Kafka sink in RisingWave, you can specify the following Kafka-sp
 | retry.backoff.ms                      | properties.retry.backoff.ms                      | int    |
 | receive.message.max.bytes             | properties.receive.message.max.bytes             | int    |
 | ssl.endpoint.identification.algorithm | properties.ssl.endpoint.identification.algorithm | str    |
+| statistics.interval.ms                | properties.statistics.interval.ms                | int    |
 
 
 Set `properties.ssl.endpoint.identification.algorithm` to `none` to bypass the verification of CA certificates and resolve SSL handshake failure. This parameter can be set to either `https` or `none`. By default, it is `https`.
+
+To monitor Kafka metrics in Grafana, set `properties.statistics.interval.ms` to a non-zero value. The granularity is 1000ms.
 
 Starting with version 2.0, the default value for `properties.message.timeout.ms` has changed from 5 seconds to **5 minutes**, aligning with the default setting in the [official Kafka library](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).
 

--- a/integrations/sources/kafka.mdx
+++ b/integrations/sources/kafka.mdx
@@ -92,6 +92,9 @@ When creating a source in RisingWave, you can specify the following Kafka parame
 | queued.min.messages                   | properties.queued.min.messages                   | int     |
 | receive.message.max.bytes             | properties.receive.message.max.bytes             | int     |
 | ssl.endpoint.identification.algorithm | properties.ssl.endpoint.identification.algorithm | str     |
+| statistics.interval.ms                | properties.statistics.interval.ms                | int     |
+
+To monitor Kafka metrics in Grafana, set `properties.statistics.interval.ms` to a non-zero value. The granularity is 1000ms.
 
 The additional Kafka parameters `queued.min.messages` and `queued.max.messages.kbytes` are specified with `properties.queued.min.messages` and `properties.queued.max.messages.kbytes`, respectively, when creating the source.
 


### PR DESCRIPTION
as title, we supported it long ago but not documented