### PR TITLE
Add XML and YAML to EXPLAIN FORMAT

### DIFF
--- a/changelog/product-lifecycle.mdx
+++ b/changelog/product-lifecycle.mdx
@@ -23,7 +23,7 @@ Below is a list of all features in the public preview phase:
 | Feature name |  Start version |
 | :-- | :-- |
 | [Ingest data from MySQL table](/integrations/sources/mysql-table)| 2.2 |
-| [EXPLAIN FORMAT JSON](/sql/commands/sql-explain#explain-options)| 2.2 |
+| [EXPLAIN option of FORMAT](/sql/commands/sql-explain#explain-options)| 2.2 |
 | [Ingest data from Postgres table](/integrations/sources/postgresql-table) | 2.1 |
 | [Ingest data from webhook](/integrations/sources/webhook) | 2.1 |
 | [Shared source](/sql/commands/sql-create-source#shared-source)  | 2.1  |

--- a/sql/commands/sql-explain.mdx
+++ b/sql/commands/sql-explain.mdx
@@ -23,7 +23,7 @@ EXPLAIN [ ( option [ , ... ] ) ] statement;
 | **VERBOSE**  | `[ TRUE \| FALSE ]`             | Show additional information regarding the execution plan such as the table catalog of the state table and the schema of each operator.                                        |
 | **TRACE**    | `[ TRUE \| FALSE ]`             | Show the trace of each optimization stage, not only the final plan.                                                                                                          |
 | **TYPE**     | `[ PHYSICAL \| LOGICAL \| DISTSQL ]` | Show the execution plan of a specific phase.<ul><li>PHYSICAL — Show the batch plan or stream plan.</li><li>LOGICAL — Show the optimized logical plan.</li><li>DISTSQL — Show the distributed query plan for batch or stream.</li></ul> |
-| **FORMAT**    | `[ TEXT \| JSON ]`              | <ul><li>FORMAT JSON - Show the `logical` and `physical` plans in JSON format while ignoring `trace` and `distsql` options.</li><li>FORMAT TEXT - Match the current output format of `EXPLAIN`.</li></ul> |
+| **FORMAT**    | `[ TEXT \| JSON \| XML \| YAML ]`              | <ul><li>FORMAT JSON - Show the `logical` and `physical` plans in JSON format while ignoring `trace` and `distsql` options.</li><li>FORMAT TEXT - Match the current output format of `EXPLAIN`.</li><li>FORMAT XML - Show the `logical` and `physical` plans in XML format.</li><li>FORMAT YAML - Show the `logical` and `physical` plans in YAML format.</li></ul> |
 
 <Note>
 The boolean parameter `[ TRUE | FALSE ]` specifies whether the specified option should be enabled or disabled. Use `TRUE` to enable the option, and `FALSE` to disable it. It defaults to `TRUE` if the parameter is not specified.
@@ -32,7 +32,7 @@ The boolean parameter `[ TRUE | FALSE ]` specifies whether the specified option 
 <Note>
 **PUBLIC PREVIEW**
 
-`EXPLAIN FORMAT JSON` is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
+EXPLAIN option of FORMAT is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
 
 </Note>
 


### PR DESCRIPTION
## Description
Support XML and YAML to `EXPLAIN FORMAT`

## Related code PR
https://github.com/risingwavelabs/risingwave/pull/19400

## Related doc issue
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/177