### PR TITLE
Fix typo in manage-sources.mdx

### DIFF
--- a/cloud/manage-sources.mdx
+++ b/cloud/manage-sources.mdx
@@ -25,7 +25,7 @@ You can create a source with one of the following methods:
 
 ### Using SQL command
 
-Refer to [CREARE SOURCE](/sql/commands/sql-create-source) in the RisingWave documentation. Select a connector to see the SQL syntax, options, and sample statement of connecting RisingWave to the connector.
+Refer to [CREATE SOURCE](/sql/commands/sql-create-source) in the RisingWave documentation. Select a connector to see the SQL syntax, options, and sample statement of connecting RisingWave to the connector.
 
 ## Check a source
 


### PR DESCRIPTION
`CREARE SOURCE` --> `CREATE SOURCE`