### PR TITLE
Document behavior of subscription cursor

### DIFF
--- a/serve/subscription.mdx
+++ b/serve/subscription.mdx
@@ -55,7 +55,7 @@ ALTER SUBSCRIPTION <subscription_name>
 
 A subscription cursor is a unit used to consume data from a subscription. In RisingWave, it’s a tool specifically designed to work in conjunction with a subscription, differing from the general cursor.
 
-In RisingWave, the subscription cursor allows you to specify a specific starting point within the data of the subscription. Once the subscription cursor is created, you can use a loop to fetch and consume the data starting from that point onwards. A subscription can have multiple subscription cursors, which can be used to consume different ranges or intervals of data from the subscription.
+In RisingWave, the subscription cursor allows you to specify a specific starting point within the subscription data. After creating the subscription cursor, you can use a loop to fetch and consume data starting from that point onwards. Results returned by the cursor are sorted by primary key. A subscription can have multiple subscription cursors, each consuming different ranges or intervals of data from the subscription.
 
 ### Syntax[](#syntax "Direct link to Syntax")
 


### PR DESCRIPTION
## Description

Clarify that results returned by cursors are sorted by the primary key.

## Related code PR
https://github.com/risingwavelabs/risingwave/pull/18801

## Related doc issue
Resolve https://github.com/risingwavelabs/risingwave-docs-legacy/issues/2752