### PR TITLE
Document `include subject` in NATS source

### DIFF
--- a/ingestion/ingest-additional-fields-with-include-clause.mdx
+++ b/ingestion/ingest-additional-fields-with-include-clause.mdx
@@ -9,7 +9,7 @@ sidebarTitle: "Ingest additional source fields"
 To add additional columns, use the `INCLUDE` clause.
 
 ```sql
-INCLUDE { header | key | offset | partition | timestamp | payload } [AS <column_name>]
+INCLUDE { header | key | offset | partition | timestamp | payload | subject } [AS <column_name>]
 ```
 
 If `<column_name>` is not specified, a default one will be generated in the format `_rw_{connector}_{col}`, where `connector` is the name of the source connector used (Kafka, Pulsar, Kinesis, etc.), and `col` is the type of column being generated (key, offset, timestamp, etc.). For instance, if an offset column is added to a Kafka source, the default column name would be `_rw_kafka_offset`.
@@ -73,6 +73,40 @@ When ingesting data from Kinesis, here are some things to note when including th
 
 For more components, see [Struct aws\_sdk\_kinesis::types::Record](https://docs.rs/aws-sdk-kinesis/latest/aws%5Fsdk%5Fkinesis/types/struct.Record.html).
 
+### MongoDB CDC
+
+When ingesting data from MongoDB CDC, the following additional fields can be included.
+
+| Allowed components | Default type | Note                              |
+| :------------------| :------------| :---------------------------------|
+| timestamp          | `timestamp with time zone`      | The upstream commit timestamp.     |
+| partition          | `varchar`      | The partition the record is from.     |
+| offset             | `varchar`      | The offset in the partition.                 |
+| database_name             | `varchar`      | Name of the database.                 |
+| offset             | `varchar`      | Name of the MongoDB collection.                 |
+
+
+### MQTT
+
+When ingesting data from MQTT, the following additional fields can be included.
+
+| Allowed components | Default type | Note                              |
+| :------------------| :------------| :---------------------------------|
+| partition          | `varchar`      | The partition the record is from.     |
+| offset             | `varchar`      | The offset in the partition.                 |
+
+
+### NATS
+
+When ingesting data from NATS, the following additional fields can be included.
+
+| Allowed components | Default type | Note                              |
+| :------------------| :------------| :---------------------------------|
+| partition          | `varchar`      | The partition the record is from.     |
+| offset             | `varchar`      | The offset in the partition.                 |
+| payload | `json` | The actual content or data of the message. Only supports `JSON` format. |
+| subject | `varchar` |  The subject the message is from. | 
+
 ### Pulsar
 
 When ingesting data from Pulsar, here are some things to note when including the following fields.
@@ -96,13 +130,7 @@ When ingesting data from AWS S3, GCS or Azure Blob, the following additional fie
 | offset             | `varchar`      | The offset in the file.      |
 | payload | `json` | The actual content or data of the message. Only supports `JSON` format. |
 
-### MQTT
 
-When ingesting data from MQTT, the following additional fields can be included.
-
-| Allowed components | Default type | Note                              |
-| :------------------| :------------| :---------------------------------|
-| partition          | varchar      | The topic the record is from.     |
 
 ## Examples
 

--- a/ingestion/ingest-additional-fields-with-include-clause.mdx
+++ b/ingestion/ingest-additional-fields-with-include-clause.mdx
@@ -83,7 +83,7 @@ When ingesting data from MongoDB CDC, the following additional fields can be inc
 | partition          | `varchar`      | The partition the record is from.     |
 | offset             | `varchar`      | The offset in the partition.                 |
 | database_name             | `varchar`      | Name of the database.                 |
-| offset             | `varchar`      | Name of the MongoDB collection.                 |
+| collection_name           | `varchar`      | Name of the MongoDB collection.                 |
 
 
 ### MQTT

--- a/integrations/sources/nats-jetstream.mdx
+++ b/integrations/sources/nats-jetstream.mdx
@@ -32,6 +32,7 @@ When creating a source, you can choose to persist the data from the source in Ri
 ```sql
 CREATE { TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [ schema_definition ]
+[INCLUDE { partition | offset | payload | subject } [AS <column_name>]]
 WITH (
    connector='nats',
    server_url='<your nats server>:<port>', [ <another_server_url_if_available>, ...]


### PR DESCRIPTION
## Description

- See [preview](https://risingwavelabs-wyx-resolve_181.mintlify.app/ingestion/ingest-additional-fields-with-include-clause)
- Document `include subject` in NATS source
- Update the overview of include clause to align with [source code](https://github.com/PierreNowak/risingwave/blob/38a5928173ca75201530b46a8b64ed26ce959e2f/src/connector/src/parser/additional_columns.rs#L81).

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/19708

## Related doc issue

Resolve https://github.com/risingwavelabs/risingwave-docs/issues/181