### PR TITLE
fix: remove `LANGUAGE python` from the examples on external python udf doc

### DIFF
--- a/sql/udfs/use-udfs-in-python.mdx
+++ b/sql/udfs/use-udfs-in-python.mdx
@@ -135,16 +135,20 @@ Here are the SQL statements for declaring the four UDFs defined in [step 2](#2-d
 
 ```sql
 CREATE FUNCTION gcd(int, int) RETURNS int
-LANGUAGE python AS gcd USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
+AS gcd
+USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 
 CREATE FUNCTION blocking(int) RETURNS int
-LANGUAGE python AS blocking USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
+AS blocking
+USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 
 CREATE FUNCTION key_value(varchar) RETURNS struct<key varchar, value varchar> -- the field names must exactly match the ones in Python decorator
-LANGUAGE python AS key_value USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
+AS key_value
+USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 
 CREATE FUNCTION series(int) RETURNS TABLE (x int)
-LANGUAGE python AS series USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
+AS series
+USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 ```
 
 ## 5\. Use your functions in RisingWave


### PR DESCRIPTION
`LANGUAGE` option is not needed for external UDFs.