### PR TITLE
feat: add note for multiple watermark columns support in EOWC queries

### DIFF
--- a/processing/emit-on-window-close.mdx
+++ b/processing/emit-on-window-close.mdx
@@ -10,9 +10,10 @@ In streaming systems, there are typically two types of triggering policies for w
 Taking the following query as an example,
 
 ```sql
-SELECT window_start, COUNT(*)
+CREATE MATERIALIZED VIEW window_count AS
+SELECT window_start, window_end, COUNT(*)
 FROM TUMBLE(events, event_time, INTERVAL '1' MINUTE)
-GROUP BY window_start;
+GROUP BY window_start, window_end;
 ```
 
 * **Emit on update:** With this policy, the aggregation operator emits a new `count(*)` result downstream whenever each barrier passes (default interval is 1 second). This updated count is then reflected in the materialized view or outputted to external systems.
@@ -31,9 +32,9 @@ We can modify the query above to use emit-on-window-close semantics:
 
 ```sql
 CREATE MATERIALIZED VIEW window_count AS
-SELECT window_start, COUNT(*)
+SELECT window_start, window_end, COUNT(*)
 FROM TUMBLE(events, event_time, INTERVAL '1' MINUTE)
-GROUP BY window_start
+GROUP BY window_start, window_end
 EMIT ON WINDOW CLOSE;
 ```
 
@@ -48,6 +49,10 @@ CREATE SOURCE t (
 ```
 
 After making this modification, the `window_count` results will no longer include any partial aggregation results from the most recent window. Instead, a final result will only be delivered when the `event_time` watermark surpasses the end time of the window.
+
+<Note>
+Changed in version 2.3: Support grouping by `window_start` and `window_end` at the same time in emit-on-window-close queries.
+</Note>
 
 ## What queries can achieve better performance with the emit-on-window-close triggering policy?
 

--- a/processing/emit-on-window-close.mdx
+++ b/processing/emit-on-window-close.mdx
@@ -51,7 +51,7 @@ CREATE SOURCE t (
 After making this modification, the `window_count` results will no longer include any partial aggregation results from the most recent window. Instead, a final result will only be delivered when the `event_time` watermark surpasses the end time of the window.
 
 <Note>
-Changed in version 2.3: Support grouping by `window_start` and `window_end` at the same time in emit-on-window-close queries.
+Changed in v2.3: Support grouping by `window_start` and `window_end` at the same time in emit-on-window-close queries.
 </Note>
 
 ## What queries can achieve better performance with the emit-on-window-close triggering policy?


### PR DESCRIPTION
Fix #182.

Rendered: https://risingwavelabs-rc-allow-multiple-wtmk-for-eowc-hash-agg.mintlify.app/processing/emit-on-window-close