### PR TITLE
fix: refine the `sql-create-function` page

### DIFF
--- a/sql/commands/sql-create-function.mdx
+++ b/sql/commands/sql-create-function.mdx
@@ -35,19 +35,12 @@ CREATE FUNCTION function_name ( argument_type [, ...] )
 
 ### Examples
 
-Use `CREATE FUNCTION` to declare a UDF defined by Python. For more details, see [Use UDFs in Python](/sql/udfs/use-udfs-in-python).
-
-```sql
-CREATE FUNCTION gcd(int, int) RETURNS int
-LANGUAGE python AS gcd USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
-```
-
-Use `CREATE FUNCTION` to declare a UDF defined by Java. For more details, see [Use UDFs in Java](/sql/udfs/use-udfs-in-java).
+Use `CREATE FUNCTION` to declare an external UDF defined by Python or Java. For more details, see [Use UDFs in Python](/sql/udfs/use-udfs-in-python) or [Use UDFs in Java](/sql/udfs/use-udfs-in-java).
 
 ```sql
 CREATE FUNCTION gcd(int, int) RETURNS int
 AS gcd
-USING LINK 'http://localhost:8815';
+USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 ```
 
 ## Embedded UDFs
@@ -57,8 +50,8 @@ Embedded UDFs are functions that run in the language runtime embedded in RisingW
 Here are some examples of embedded UDFs, along with links to specific guides on creating them with different languages.
 
 ```sql Embedded UDFs
-# Embedded Python UDF
-create function gcd(a int, b int) returns int language python as $$
+-- Embedded Python UDF
+CREATE FUNCTION gcd(a int, b int) RETURNS int LANGUAGE python AS $$
 def gcd(a, b):
     while b != 0:
         a, b = b, a % b
@@ -69,8 +62,8 @@ $$;
 For more details, see [Embedded Python UDFs](/sql/udfs/embedded-python-udfs).
 
 ```sql Embedded UDFs
-# Embedded JavaScript UDF
-create function gcd(a int, b int) returns int language javascript as $$
+-- Embedded JavaScript UDF
+CREATE FUNCTION gcd(a int, b int) RETURNS int LANGUAGE javascript AS $$
     while (b != 0) {
         let t = b;
         b = a % b;
@@ -83,8 +76,8 @@ $$;
 For more details, see [Use UDFs in JavaScript](/sql/udfs/use-udfs-in-javascript).
 
 ```sql Embedded UDFs
-# Embedded Rust UDF
-create function gcd(int, int) returns int language rust as $$
+-- Embedded Rust UDF
+CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE rust AS $$
     fn gcd(mut a: i32, mut b: i32) -> i32 {
         while b != 0 {
             let t = b;


### PR DESCRIPTION
## Description

- Unify the case.
- Remove duplication.

## Rendered

https://risingwavelabs-rc-refine-sql-create-function.mintlify.app/sql/commands/sql-create-function