### PR TITLE
Missing note of Parquet source

### DIFF
--- a/ingestion/overview.mdx
+++ b/ingestion/overview.mdx
@@ -156,6 +156,10 @@ SELECT count(*) from s3_source;
 
 When using file source to read parquet files, please define the schema information according to the following mapping.
 
+<Note>
+The Parquet source requires case-sensitive column names, but PostgreSQL converts unquoted column names to lowercase by default. Use double quotes when defining the schema to preserve case sensitivity.
+</Note>
+
 | Parquet data type | RisingWave file source data type |
 | :----------- | :-------------- |
 | boolean      | boolean         |


### PR DESCRIPTION
Add a note of using double quotes around column names for Parquet source

Resolve https://github.com/risingwavelabs/risingwave-docs/issues/239