### PR TITLE
Document: reduce `jdbc.query.timeout` to 60s

### DIFF
--- a/integrations/destinations/mysql.mdx
+++ b/integrations/destinations/mysql.mdx
@@ -124,7 +124,7 @@ WITH (
 | jdbc.url            | Required. The JDBC URL of the destination database necessary for the driver to recognize and connect to the database.                                                                                                      |
 | user                | The user name for the database connection. |
 | password            | The password for the database connection. |
-| jdbc.query.timeout  | Specifies the timeout for the operations to downstream. If not set, the default is 10 minutes.                                                                                                                   |
+| jdbc.query.timeout  | Specifies the timeout for the operations to downstream. If not set, the default is 60s.                                                                                                                   |
 | table.name          | Required. The table in the destination database you want to sink to.                                                                                                                                                       |
 | type                | Data format. Allowed formats: <ul><li>`append-only`: Output data with insert operations.</li><li>`upsert`: Output data as a changelog stream.</li></ul>           |
 | primary\_key        | Required if type is upsert. The primary key of the downstream table.                                                                                                                                             |

--- a/integrations/destinations/postgresql.mdx
+++ b/integrations/destinations/postgresql.mdx
@@ -99,7 +99,7 @@ WITH (
 | jdbc.url            | Required. The JDBC URL of the destination database necessary for the driver to recognize and connect to the database. |
 | user                | The user name for the database connection. |
 | password            | The password for the database connection. |
-| jdbc.query.timeout  | Specifies the timeout for the operations to downstream. If not set, the default is 10 minutes.                                                                                                                   |
+| jdbc.query.timeout  | Specifies the timeout for the operations to downstream. If not set, the default is 60s.                                                                                                                   |
 | table.name          | Required. The table in the destination database you want to sink to.                                                                                                                                                       |
 | schema.name         | The schema in the destination database you want to sink to. The default value is public.                                                                                                               |
 | type                | Sink data type. Supported types: <ul><li>`append-only`: Sink data as INSERT operations.</li><li>`upsert`: Sink data as UPDATE, INSERT and DELETE operations.</li></ul>                                                                        |


### PR DESCRIPTION
Related code PR: https://github.com/risingwavelabs/risingwave/pull/20641

Resolve https://github.com/risingwavelabs/risingwave-docs/issues/261