### PR TITLE
Document: support switch database of the current session

### DIFF
--- a/sql/commands/sql-set.mdx
+++ b/sql/commands/sql-set.mdx
@@ -15,3 +15,17 @@ SET parameter_name { TO | = } { value | 'value' | DEFAULT};
 | :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | _parameter\_name_   | Name of the runtime parameters.                                                                                                                                                                                                                                                                                                                           |
 | _value_             | New value of parameter. Values can be specified as string constants, identifiers, numbers, or comma-separated lists of these, as appropriate for the particular parameter. DEFAULT can be written to specify resetting the parameter to its default value (that is, whatever value it would have had if no SET had been executed in the current session). |
+
+## Special case
+
+In addition to standard parameter settings, RisingWave supports switching databases during an active session using either `SET DATABASE TO` or `USE`. Both commands allow you to change the current database without disconnecting and reconnecting.
+
+```sql Example
+-- Switch database using SET DATABASE TO 
+SET DATABASE TO sales_db
+
+-- Switch database using USE
+USE marketing_db
+```
+
+

--- a/sql/commands/sql-set.mdx
+++ b/sql/commands/sql-set.mdx
@@ -22,10 +22,10 @@ In addition to standard parameter settings, RisingWave supports switching databa
 
 ```sql Example
 -- Switch database using SET DATABASE TO 
-SET DATABASE TO sales_db
+SET DATABASE TO sales_db;
 
 -- Switch database using USE
-USE marketing_db
+USE marketing_db;
 ```
 
 


### PR DESCRIPTION
## Description

Add `SET DATABASE TO` and `USE` to switch database

## Related code PR
https://github.com/risingwavelabs/risingwave/pull/19786

## Related doc issue
Fix https://github.com/risingwavelabs/risingwave-docs/issues/203