### PR TITLE
update generated-columns limits

### DIFF
--- a/sql/query-syntax/generated-columns.mdx
+++ b/sql/query-syntax/generated-columns.mdx
@@ -17,8 +17,10 @@ CREATE TABLE t1 (v1 int AS v2-1, v2 int, v3 int AS v2+1);
 
 A generated column in a table is slightly different from one in a source.
 
-* A generated column in a table is stored in the created table, and computed when it is inserted. This is equivalent to the `STORED` type of generated columns in PostgreSQL. If a table contains a generated column, the table cannot be updated or deleted in RisingWave.
+* The generated column with impure expressions can not be part of the primary key.
+* A generated column in a table is stored in the created table, and computed when it is inserted. This is equivalent to the `STORED` type of generated columns in PostgreSQL.
 * A generated column in a source is not stored in the created source, and is computed when the source is queried. This is equivalent to the `VIRTUAL` type of generated columns in PostgreSQL.
+
 
 To create a generated column as the processing time of a message, use the `proctime()` function, for example:
 


### PR DESCRIPTION
It is out-of-date

```SQL
dev=> create table t(v int, a int as v+v);
CREATE_TABLE
dev=> update t set v =1 ;
UPDATE 0
dev=> drop table t;
DROP_TABLE
dev=> create table t(v int, a timestamptz as proctime());
CREATE_TABLE
dev=> update t set v =1 ;
UPDATE 0
dev=> drop table t;
dev=> create table t(v int, a timestamptz as proctime(), primary key(a));
ERROR:  Failed to run the query

Caused by:
  Bind error: Generated columns with impure expressions should not be part of the primary key. Here column "a" is defined as part of the primary key.

dev=> create table t(v int, a int as v+v, primary key(a));
CREATE_TABLE
```