### PR TITLE
Document: handle gaps in time windows

### DIFF
--- a/processing/sql/time-windows.mdx
+++ b/processing/sql/time-windows.mdx
@@ -252,6 +252,89 @@ The result looks like this:
  2       | 2022-07-01 22:05:00 | 2
 ```
 
+## Handle gaps in time windows
+
+If no events occur during specific intervals, gaps may appear in time windows. To ensure continuous and complete time windows, use [`generate_series()`](/sql/functions/set-returning#advanced-usage-of-generating-timestamp) to fill in missing intervals.
+
+### Problem
+
+Consider a dataset of taxi trips where each trip is recorded with a completion timestamp:
+
+```bash 
+ trip_id | taxi_id | completed_at         | distance | duration 
+---------+---------+----------------------+----------+----------
+ 1       | 1001    | 2022-07-01 22:00:00  | 4        | 6        
+ 2       | 1002    | 2022-07-01 22:01:00  | 6        | 9        
+ 3       | 1003    | 2022-07-01 22:02:10  | 3        | 5        
+ 4       | 1004    | 2022-07-01 22:03:00  | 7        | 15       
+ 5       | 1005    | 2022-07-01 22:07:00  | 2        | 4        
+ 6       | 1006    | 2022-07-01 22:08:30  | 8        | 17       
+```
+
+Using a 2-minute tumbling window, we aggregate the trip counts per window:
+
+```sql
+SELECT window_start, window_end, COUNT(*) AS trip_count
+FROM TUMBLE (taxi_trips, completed_at, INTERVAL '2 MINUTES')
+GROUP BY window_start, window_end;
+```
+
+The result looks like this:
+
+```bash
+ window_start        | window_end           | trip_count 
+---------------------+----------------------+------------
+ 2022-07-01 22:00:00 | 2022-07-01 22:02:00  | 2          
+ 2022-07-01 22:02:00 | 2022-07-01 22:04:00  | 2          
+ 2022-07-01 22:06:00 | 2022-07-01 22:08:00  | 1          
+ 2022-07-01 22:08:00 | 2022-07-01 22:10:00  | 1          
+```
+
+Here the time window `2022-07-01 22:04:00 - 2022-07-01 22:06:00` is missing because no trips were recorded during that interval.
+
+### Solution
+
+To ensure continuous time windows, we can generate a full range of expected time windows and LEFT JOIN them with the aggregated results.
+
+```sql
+WITH time_series AS (
+    SELECT 
+        generate_series(
+            TIMESTAMP '2022-07-01 22:00:00',  -- Start time
+            NOW(),  -- End time
+            INTERVAL '2 MINUTES'              -- Step size
+        ) AS window_start
+)
+SELECT 
+    ts.window_start,
+    ts.window_start + INTERVAL '2 MINUTES' AS window_end,
+    COALESCE(t.trip_count, 0) AS trip_count
+FROM time_series ts
+LEFT JOIN (
+    SELECT 
+        window_start, 
+        COUNT(*) AS trip_count
+    FROM TUMBLE (taxi_trips, completed_at, INTERVAL '2 MINUTES')
+    GROUP BY window_start
+) t
+ON ts.window_start = t.window_start
+ORDER BY ts.window_start;
+```
+
+The final output would be continuous time windows with `0` filling for missing intervals.
+
+```bash
+ window_start         | window_end           | trip_count 
+----------------------+----------------------+------------
+ 2022-07-01 22:00:00  | 2022-07-01 22:02:00  | 2          
+ 2022-07-01 22:02:00  | 2022-07-01 22:04:00  | 2          
+ 2022-07-01 22:04:00  | 2022-07-01 22:06:00  | 0          
+ 2022-07-01 22:06:00  | 2022-07-01 22:08:00  | 1          
+ 2022-07-01 22:08:00  | 2022-07-01 22:10:00  | 1          
+```
+
+This approach ensures that every expected time window is included, even if no events occurred in some intervals.
+
 ## Window joins
 
 You can join a time window with a table, or another time window that is of the same type and has the same time attributes.

--- a/sql/functions/set-returning.mdx
+++ b/sql/functions/set-returning.mdx
@@ -6,6 +6,8 @@ title: "Set-returning functions"
 
 The `generate_series()` function in PostgreSQL is a set-returning function that generates a series of values, based on the start and end values defined by the user. It is useful for generating test data or for creating a sequence of numbers or timestamps.
 
+### Basic syntax and example
+
 The syntax for the `generate_series()` function is as follows:
 
 ```sql
@@ -76,6 +78,8 @@ The result looks like this:
 2008-03-04 00:00:00
 2008-03-04 12:00:00
 ```
+
+### Advanced usage of generating timestamp 
 
 Except for generating a static set of values, RisingWave also supports continuously generating timestamps at specified intervals into a materialized view. To achieve this, use `now()` as the `stop` parameter in the `generate_series()` function. For example:
 


### PR DESCRIPTION
## Description
Fix https://github.com/risingwavelabs/risingwave-docs/issues/284, convert it into doc, see [preview](https://risingwavelabs-wyx-resolve_284.mintlify.app/processing/sql/time-windows#handle-gaps-in-time-windows).
BTW, shall we add [this](https://github.com/risingwavelabs/risingwave-docs/issues/284#issuecomment-2703001128) into the note?

Let me know if any questions, thanks!
