### PR TITLE
Document: update behavior in create table and alter table

### DIFF
--- a/sql/commands/sql-alter-table.mdx
+++ b/sql/commands/sql-alter-table.mdx
@@ -35,7 +35,7 @@ ALTER TABLE employees ADD age int;
 ```
 
 <Note>
-* If your table is defined with a schema registry, its columns can not be altered.
+* If your table is defined with a schema registry, you can change the table schema by `ALTER TABLE t REFRESH SCHEMA` or `ALTER TABLE ADD COLUMN`.
 * Columns added by this command cannot be used by any existing materialized views or indexes. You must create new materialized views or indexes to reference it.
 </Note>
 
@@ -58,7 +58,7 @@ ALTER TABLE employees DROP fax;
 ```
 
 <Note>
-* If your table is defined with a schema registry, you can only change the table schema by `ALTER TABLE t REFRESH SCHEMA`. One exception is you can drop the generated columns even if the schema is defined with a schema registry. Note that dropping these generated columns will trigger a schema refresh.
+* If your table is defined with a schema registry, you can change the table schema by `ALTER TABLE t REFRESH SCHEMA` or `ALTER TABLE DROP COLUMN`.
 * You cannot drop columns referenced by materialized views or indexes.
 * To drop a column referenced by a generated column, you must first drop the generated column.
 </Note>

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -44,9 +44,10 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 
 - To know when a data record is loaded to RisingWave, you can define a column that is generated based on the processing time (`<column_name> timestamptz AS proctime()`) when creating the table or source. See also [proctime()](/sql/functions/datetime#proctime).
 
-- For a table with schema from external connector, use `*` to represent all columns from the external connector first, so that you can define a generated column on table with an external connector. See the example below
+- For a table with schema from external connector, use `*` to represent all columns from the external connector first, so that you can define a generated column on table with an external connector. Alternatively, you can partially combine the schema with generated columns or apply the schema directly to define the table structure. See the examples below:
 
   ```sql
+  -- Use * to represent all columns
   CREATE TABLE from_kafka (
     *,
     gen_i32_field INT AS int32_field + 2,
@@ -54,6 +55,17 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
   )
   INCLUDE KEY AS some_key
   [INCLUDE { header | offset | partition | timestamp } [AS <column_name>]]
+  WITH (
+    connector = 'kafka',
+    topic = 'test-rw-sink-upsert-avro',
+    properties.bootstrap.server = 'message_queue:29092'
+  )
+  FORMAT upsert ENCODE AVRO (
+    schema.registry = 'http://message_queue:8081'
+  );
+
+  -- Specify partial schema
+  CREATE TABLE t2 (bar INT, gen_col INT AS bar + 1)
   WITH (
     connector = 'kafka',
     topic = 'test-rw-sink-upsert-avro',


### PR DESCRIPTION
## Description
In `create table`, support specify schema with generated columns, or apply the schema directly as columns
In `alter table`, support using `ALTER TABLE [ADD | DROP] COLUMN` to update schema.

Let me know if any comments, thanks!

## Related code issue
https://github.com/risingwavelabs/risingwave/pull/20203

## Related doc PR
Fix https://github.com/risingwavelabs/risingwave-docs/issues/232