### PR TITLE
Fix: add note of version

### DIFF
--- a/integrations/sources/azure-blob.mdx
+++ b/integrations/sources/azure-blob.mdx
@@ -60,6 +60,10 @@ FORMAT data_format ENCODE data_encode (
 
 ## Read Parquet files from Azure Blob
 
+<Note>
+Added in version 2.3.
+</Note>
+
 You can use the table function `file_scan()` to read Parquet files from Azure Blob, either a single file or a directory of Parquet files.
 
 ```sql Function signature

--- a/integrations/sources/google-cloud-storage.mdx
+++ b/integrations/sources/google-cloud-storage.mdx
@@ -64,6 +64,10 @@ For example, RisingWave reads file F1 to offset O1 and crashes. After RisingWave
 
 ## Read Parquet files from GCS
 
+<Note>
+Added in version 2.3.
+</Note>
+
 You can use the table function `file_scan()` to read Parquet files from GCS, either a single file or a directory of Parquet files.
 
 ```sql Function signature


### PR DESCRIPTION
Read Parquet files from Azure Blob and GCS is supported since v2.3