### PR TITLE
Document: add `rw_license()` to retrieve license info

### DIFF
--- a/get-started/rw-premium-edition-intro.mdx
+++ b/get-started/rw-premium-edition-intro.mdx
@@ -196,6 +196,21 @@ SELECT rw_test_paid_tier();
 
 A result of `t` means the key is valid; an error message indicates an invalid key.
 
+### Retrieve license details
+
+To retrieve detailed license information, run:
+
+```sql
+SELECT rw_license();
+```
+
+If the current license is valid, the output will look like this:
+
+```json
+{"cpu_core_limit": null, "exp": 9999999999, "iss": "test.risingwave.com", "sub": "rw-test", "tier": "paid"}
+```
+Otherwise, an error message will indicate the issue (e.g., invalid token, expired license).
+
 ## Support package
 
 RisingWave provides three levels of support packages:


### PR DESCRIPTION
## Description
Add `rw_license()` in doc to retrieve license info.

## Related code PR
https://github.com/risingwavelabs/risingwave/pull/20629

## Related doc issue
Fix https://github.com/risingwavelabs/risingwave-docs/issues/258