### PR TITLE
add Iceberg landing page and links

### DIFF
--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -28,7 +28,7 @@ description: This page summarizes changes in each version of RisingWave, includi
 - Supports nested `Ref` for Avro encoding, except for circular dependency. [#19601](https://github.com/risingwavelabs/risingwave/pull/19601), [#19701](https://github.com/risingwavelabs/risingwave/pull/19701), [#19746](https://github.com/risingwavelabs/risingwave/pull/19746)
 - Adds parameter `messages_as_jsonb` for source’s Protobuf encoding when creating a source or table. [#19935](https://github.com/risingwavelabs/risingwave/pull/19935)
 - Supports `_rw_timestamp` system column for tables. [#19232](https://github.com/risingwavelabs/risingwave/pull/19232)
-- Allows Iceberg REST catalog to be specified as  `catalog.credential`, `catalog.scope`, `catalog.oauth2-server-uri`, or `catalog.token`. [#19406](https://github.com/risingwavelabs/risingwave/pull/19406)
+- Allows Iceberg REST catalog to be specified as  `catalog.credential`, `catalog.scope`, `catalog.oauth2_server_uri`, or `catalog.token`. [#19406](https://github.com/risingwavelabs/risingwave/pull/19406)
 - Supports configuring parameter `commit_checkpoint_interval` when creating Iceberg engine tables. The default value is `60`.  [#19738](https://github.com/risingwavelabs/risingwave/pull/19738)
 - Supports `INCLUDE partition` when creating MQTT sources to include which topic each message is from. [#19017](https://github.com/risingwavelabs/risingwave/pull/19017)
 - Supports `INCLUDE subject` when creating NATS sources. [#19708](https://github.com/risingwavelabs/risingwave/pull/19708)

--- a/iceberg/iceberg-table-engine.mdx
+++ b/iceberg/iceberg-table-engine.mdx
@@ -1,0 +1,5 @@
+---
+title: "Iceberg table engine"
+sidebarTitle: "Iceberg table engine"
+url: "/store/iceberg-table-engine"
+---

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -20,7 +20,7 @@ This topic provides an overview of these methods.
 
 You can create an Iceberg source in RisingWave to read data from an existing Iceberg table. These tables typically reside in object storage (like S3, HDFS) and their metadata/data lifecycle is managed by systems other than RisingWave. This allows you to ingest data from your existing data lake directly into RisingWave.
 
-- Use Case: Ingesting data into RisingWave from Iceberg tables populated by other batch or streaming systems.
+- Use case: Ingesting data into RisingWave from Iceberg tables populated by other batch or streaming systems.
 
 - How: Use the `CREATE SOURCE` command with `connector = 'iceberg'`. You'll need to configure connection details for the Iceberg catalog and the underlying object storage. For details, see [Ingest data from Iceberg](/ingestion/sources/iceberg).
 

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -57,3 +57,73 @@ WITH (
 ```
 
 <Note>Ensure that the necessary networking and credentials (like S3 access keys and catalog authentication tokens) are correctly configured and accessible from your RisingWave cluster.</Note>
+
+## Integrate Iceberg with Amazon S3 Tables
+
+Amazon S3 Tables introduces table management APIs compatible with the Apache Iceberg REST Catalog standard, allowing any Iceberg-compatible application to create, update, list, and delete tables in an S3 table bucket.  
+
+This enables **Iceberg Source, Iceberg Sink, and Iceberg Table Engine** to connect with S3 Tables. Specifically, S3 Tables offer automatic compaction, so when using the Iceberg table engine with AWS S3 Tables, they provide an alternative solution until Iceberg compaction becomes available in future releases.
+
+The following examples show how to connect, read, and write data using Iceberg with Amazon S3 Tables.
+
+```sql
+create connection my_conn
+with (
+    type = 'iceberg',
+    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
+    s3.access.key = 'xxxx',
+    s3.secret.key = 'xxxx',
+    s3.region = 'us-east-1',
+    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
+    catalog.rest.signing_region='us-east-1',
+    catalog.rest.sigv4_enabled=true,
+    catalog.rest.signing_name='s3tables',
+    catalog.type = 'rest',
+);
+set iceberg_engine_connection = 'public.my_conn';
+alter system set iceberg_engine_connection = 'public.my_conn';
+
+create table t(id int primary key, name varchar) with(commit_checkpoint_interval = 5) engine = iceberg;
+```
+
+```sql
+create source t(*)
+with (
+    connector = 'iceberg',
+    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
+    s3.access.key = 'xxxx',
+    s3.secret.key = 'xxxx',
+    s3.region = 'us-east-1',
+    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
+    catalog.rest.signing_region='us-east-1',
+    catalog.rest.sigv4_enabled=true,
+    catalog.rest.signing_name='s3tables',
+    catalog.type = 'rest',
+    table.name = 't',
+    database.name = 'myns'
+);
+```
+
+```sql
+create table t2 (id int primary key, v int);
+create sink s from t2
+with (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
+    s3.access.key = 'xxxx',
+    s3.secret.key = 'xxxx',
+    s3.region = 'us-east-1',
+    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
+    catalog.rest.signing_region='us-east-1',
+    catalog.rest.sigv4_enabled=true,
+    catalog.rest.signing_name='s3tables',
+    catalog.type = 'rest',
+    table.name = 't2',
+    database.name = 'myns',
+    create_table_if_not_exists = true
+);
+```
+
+For details on connecting to the `rest` catalog provided by S3 Tables, refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-open-source.html).

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -33,7 +33,7 @@ To stream data from RisingWave into Iceberg tables, use the CREATE SINK statemen
 
 The following example assumes a stream or materialized view named `mv_name` exists in RisingWave. It demonstrates sinking data to an Iceberg table managed by a [REST catalog](https://iceberg.apache.org/concepts/catalog/#decoupling-using-the-rest-catalog).
 
-```sql Example
+```sql
 CREATE SINK sink_demo_rest FROM t
 WITH (
     connector = 'iceberg',
@@ -67,28 +67,32 @@ This enables **Iceberg Source, Iceberg Sink, and Iceberg Table Engine** to conne
 The following examples show how to connect, read, and write data using Iceberg with Amazon S3 Tables.
 
 ```sql
-create connection my_conn
-with (
+CREATE CONNECTION my_conn
+WITH (
     type = 'iceberg',
     warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
     s3.access.key = 'xxxx',
     s3.secret.key = 'xxxx',
     s3.region = 'us-east-1',
     catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
-    catalog.rest.signing_region='us-east-1',
-    catalog.rest.sigv4_enabled=true,
-    catalog.rest.signing_name='s3tables',
-    catalog.type = 'rest',
+    catalog.rest.signing_region = 'us-east-1',
+    catalog.rest.sigv4_enabled = true,
+    catalog.rest.signing_name = 's3tables',
+    catalog.type = 'rest'
 );
-set iceberg_engine_connection = 'public.my_conn';
-alter system set iceberg_engine_connection = 'public.my_conn';
 
-create table t(id int primary key, name varchar) with(commit_checkpoint_interval = 5) engine = iceberg;
+SET iceberg_engine_connection = 'public.my_conn';
+ALTER SYSTEM SET iceberg_engine_connection = 'public.my_conn';
+
+CREATE TABLE t (
+    id INT PRIMARY KEY,
+    name VARCHAR
+) WITH (commit_checkpoint_interval = 5) ENGINE = iceberg;
 ```
 
 ```sql
-create source t(*)
-with (
+CREATE SOURCE t(*)
+WITH (
     connector = 'iceberg',
     warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
     s3.access.key = 'xxxx',
@@ -105,9 +109,13 @@ with (
 ```
 
 ```sql
-create table t2 (id int primary key, v int);
-create sink s from t2
-with (
+CREATE TABLE t2 (
+    id INT PRIMARY KEY,
+    v INT
+);
+
+CREATE SINK s FROM t2
+WITH (
     connector = 'iceberg',
     type = 'upsert',
     primary_key = 'id',
@@ -116,9 +124,9 @@ with (
     s3.secret.key = 'xxxx',
     s3.region = 'us-east-1',
     catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
-    catalog.rest.signing_region='us-east-1',
-    catalog.rest.sigv4_enabled=true,
-    catalog.rest.signing_name='s3tables',
+    catalog.rest.signing_region = 'us-east-1',
+    catalog.rest.sigv4_enabled = true,
+    catalog.rest.signing_name = 's3tables',
     catalog.type = 'rest',
     table.name = 't2',
     database.name = 'myns',

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -1,14 +1,28 @@
 ---
-title: Using Iceberg with RisingWave
-description: "Learn how to read data from and write data to Apache Iceberg tables using RisingWave's built-in source and sink connectors."
+title: Interact with Iceberg
+description: "Learn about different ways to use Iceberg with RisingWave"
 ---
-RisingWave integrates with Apache Iceberg, allowing you to perform batch reads using the built-in Iceberg source connector and streaming writes using the built-in Iceberg sink connector.
+Apache Iceberg is a high-performance format for huge analytic tables stored typically on object storage. RisingWave offers several ways to interact with tables using the Iceberg format, enabling you to leverage Iceberg's capabilities within your streaming pipelines.
 
-This enables you to build a streaming lakehouse architecture with RisingWave. You can ingest data from Iceberg for real-time processing or sink processed results back into Iceberg, potentially using other query engines alongside RisingWave for diverse analytical needs.
+It's important to understand that RisingWave's own internal storage system (Hummock) also commonly uses object storage (like S3) to persist data, but it does so using a row-based format optimized for RisingWave's internal operations.
 
-## Read data from Iceberg tables (batch source)
+When interacting with Iceberg, you are working with data stored in the columnar Iceberg format on object storage. RisingWave provides the following interaction methods:
 
-To ingest data *from* Iceberg tables into RisingWave, use the `CREATE SOURCE` statement. For detailed syntax and parameter explanations, see [Ingest data from Iceberg](/ingestion/sources/iceberg).
+- Read data from Iceberg tables managed externally: Use the native Iceberg source connector to ingest data into RisingWave from Iceberg tables that are created and managed outside of RisingWave (e.g., by Spark, Flink, or batch ETL jobs).
+
+- Write data to Iceberg tables managed externally: Use the native Iceberg sink connector to stream processed results from RisingWave out to these externally managed Iceberg tables.
+
+- Store data natively within RisingWave using the Iceberg format: Use the Iceberg table engine to create and manage tables directly within RisingWave, but store their data in the Iceberg format on configured object storage, using an Iceberg catalog.
+
+This topic provides an overview of these methods.
+
+## Read from externally managed Iceberg tables (Iceberg source)
+
+You can create an Iceberg source in RisingWave to read data from an existing Iceberg table. These tables typically reside in object storage (like S3, HDFS) and their metadata/data lifecycle is managed by systems other than RisingWave. This allows you to ingest data from your existing data lake directly into RisingWave.
+
+- Use Case: Ingesting data into RisingWave from Iceberg tables populated by other batch or streaming systems.
+
+- How: Use the `CREATE SOURCE` command with `connector = 'iceberg'`. You'll need to configure connection details for the Iceberg catalog and the underlying object storage. For details, see [Ingest data from Iceberg](/ingestion/sources/iceberg).
 
 The following example demonstrates creating a source that reads from an Iceberg table stored on AWS S3:
 
@@ -27,11 +41,13 @@ WITH (
 ) ;
 ```
 
-## Write data to Iceberg tables
+## Write to externally managed Iceberg tables (Iceberg sink)
 
-To stream data from RisingWave into Iceberg tables, use the CREATE SINK statement. For detailed syntax and parameter explanations,  see [Sink data to Iceberg](/integrations/destinations/apache-iceberg).
+You can create an Iceberg sink to stream data from RisingWave (e.g., from a table, source, or materialied view) into an Iceberg table that is managed externally. This is useful for exporting processed results to update a data lake built on Iceberg.
 
-The following example assumes a stream or materialized view named `mv_name` exists in RisingWave. It demonstrates sinking data to an Iceberg table managed by a [REST catalog](https://iceberg.apache.org/concepts/catalog/#decoupling-using-the-rest-catalog).
+- Use case: Exporting processed streaming data from RisingWave to an existing data lake managed outside RisingWave.
+
+- How: Use the `CREATE SINK` command with `connector = 'iceberg'`. You need to configure the Iceberg catalog and object storage connection details corresponding to the target external table.
 
 ```sql
 CREATE SINK sink_demo_rest FROM t
@@ -56,82 +72,16 @@ WITH (
 );
 ```
 
-<Note>Ensure that the necessary networking and credentials (like S3 access keys and catalog authentication tokens) are correctly configured and accessible from your RisingWave cluster.</Note>
+For details, see [Sink data to Iceberg](/integrations/destinations/apache-iceberg).
 
-## Integrate Iceberg with Amazon S3 Tables
+## Store data natively in Iceberg format (Iceberg table engine)
 
-Amazon S3 Tables introduces table management APIs compatible with the Apache Iceberg REST Catalog standard, allowing any Iceberg-compatible application to create, update, list, and delete tables in an S3 table bucket.  
+RisingWave can store data directly in the Apache Iceberg format using the Iceberg table engine, and manage them natively within RisingWave. This provides an alternative to RisingWave's default internal storage format.
 
-This enables **Iceberg Source, Iceberg Sink, and Iceberg Table Engine** to connect with S3 Tables. Specifically, S3 Tables offer automatic compaction, so when using the Iceberg table engine with AWS S3 Tables, they provide an alternative solution until Iceberg compaction becomes available in future releases.
+When you create a table using `ENGINE = iceberg`, you are creating an Iceberg table. RisingWave manages the table's lifecycle, schema, and write operations, but persists the data according to the Iceberg specification on configured object storage, using a specified Iceberg catalog.
 
-The following examples show how to connect, read, and write data using Iceberg with Amazon S3 Tables.
+Tables created this way are standard Iceberg tables and can be read by other Iceberg-compatible engines (like Spark, Trino, Flink) using the same catalog and storage configuration, promoting interoperability.
 
-```sql
-CREATE CONNECTION my_conn
-WITH (
-    type = 'iceberg',
-    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
-    s3.access.key = 'xxxx',
-    s3.secret.key = 'xxxx',
-    s3.region = 'us-east-1',
-    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
-    catalog.rest.signing_region = 'us-east-1',
-    catalog.rest.sigv4_enabled = true,
-    catalog.rest.signing_name = 's3tables',
-    catalog.type = 'rest'
-);
+This simplifies streaming pipelines where the final desired format is Iceberg and enables the data to be easily shared with other systems.
 
-SET iceberg_engine_connection = 'public.my_conn';
-ALTER SYSTEM SET iceberg_engine_connection = 'public.my_conn';
-
-CREATE TABLE t (
-    id INT PRIMARY KEY,
-    name VARCHAR
-) WITH (commit_checkpoint_interval = 5) ENGINE = iceberg;
-```
-
-```sql
-CREATE SOURCE t(*)
-WITH (
-    connector = 'iceberg',
-    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
-    s3.access.key = 'xxxx',
-    s3.secret.key = 'xxxx',
-    s3.region = 'us-east-1',
-    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
-    catalog.rest.signing_region='us-east-1',
-    catalog.rest.sigv4_enabled=true,
-    catalog.rest.signing_name='s3tables',
-    catalog.type = 'rest',
-    table.name = 't',
-    database.name = 'myns'
-);
-```
-
-```sql
-CREATE TABLE t2 (
-    id INT PRIMARY KEY,
-    v INT
-);
-
-CREATE SINK s FROM t2
-WITH (
-    connector = 'iceberg',
-    type = 'upsert',
-    primary_key = 'id',
-    warehouse.path = 'arn:aws:s3tables:us-east-1:xxxxx:bucket/xxxxx',
-    s3.access.key = 'xxxx',
-    s3.secret.key = 'xxxx',
-    s3.region = 'us-east-1',
-    catalog.uri = 'https://s3tables.us-east-1.amazonaws.com/iceberg',
-    catalog.rest.signing_region = 'us-east-1',
-    catalog.rest.sigv4_enabled = true,
-    catalog.rest.signing_name = 's3tables',
-    catalog.type = 'rest',
-    table.name = 't2',
-    database.name = 'myns',
-    create_table_if_not_exists = true
-);
-```
-
-For details on connecting to the `rest` catalog provided by S3 Tables, refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-open-source.html).
+For complete instructions on setup, configuration options (like catalog types, commit intervals), features (like time travel), and limitations, see [Iceberg table engine](/store/iceberg-table-engine).

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -1,0 +1,59 @@
+---
+title: Using Iceberg with RisingWave
+description: "Learn how to read data from and write data to Apache Iceberg tables using RisingWave's built-in source and sink connectors."
+---
+RisingWave integrates with Apache Iceberg, allowing you to perform batch reads using the built-in Iceberg source connector and streaming writes using the built-in Iceberg sink connector.
+
+This enables you to build a streaming lakehouse architecture with RisingWave. You can ingest data from Iceberg for real-time processing or sink processed results back into Iceberg, potentially using other query engines alongside RisingWave for diverse analytical needs.
+
+## Read data from Iceberg tables (batch source)
+
+To ingest data *from* Iceberg tables into RisingWave, use the `CREATE SOURCE` statement. For detailed syntax and parameter explanations, see [Ingest data from Iceberg](/ingestion/sources/iceberg).
+
+The following example demonstrates creating a source that reads from an Iceberg table stored on AWS S3:
+
+```sql
+CREATE SOURCE iceberg_source
+WITH (
+    connector = 'iceberg',
+    type='append-only',
+    warehouse.path = 's3://your-bucket/path/to/iceberg/warehouse',
+    database.name = 'YOUR_ICEBERG_DB',
+    table.name = 'YOUR_ICEBERG_TABLE',
+    s3.endpoint = 'http://YOUR_S3_ENDPOINT:PORT', -- e.g., 'http://minio:9000'
+    s3.access.key = 'YOUR_ACCESS_KEY',
+    s3.secret.key = 'YOUR_SECRET_KEY',
+    s3.region = 'YOUR_S3_REGION'  -- Optional if endpoint is specified
+) ;
+```
+
+## Write data to Iceberg tables
+
+To stream data from RisingWave into Iceberg tables, use the CREATE SINK statement. For detailed syntax and parameter explanations,  see [Sink data to Iceberg](/integrations/destinations/apache-iceberg).
+
+The following example assumes a stream or materialized view named `mv_name` exists in RisingWave. It demonstrates sinking data to an Iceberg table managed by a [REST catalog](https://iceberg.apache.org/concepts/catalog/#decoupling-using-the-rest-catalog).
+
+```sql Example
+CREATE SINK sink_demo_rest FROM t
+WITH (
+    connector = 'iceberg',
+    type = 'append-only',
+    force_append_only = true,
+    s3.endpoint = 'https://s3.ap-southeast-2.amazonaws.com',
+    s3.region = 'ap-southeast-2',
+    s3.access.key = 'xxxx',
+    s3.secret.key = 'xxxx',
+    s3.path.style.access = 'true',
+    catalog.type = 'rest',
+    catalog.uri = 'http://localhost:8181/api/catalog',
+    warehouse.path = 'quickstart_catalog',
+    database.name = 'ns',
+    table.name = 't1',
+    catalog.credential='123456:123456',
+    catalog.scope='PRINCIPAL_ROLE:ALL',
+    catalog.oauth2-server-uri='xxx'
+    catalog.scope='xxx',
+);
+```
+
+<Note>Ensure that the necessary networking and credentials (like S3 access keys and catalog authentication tokens) are correctly configured and accessible from your RisingWave cluster.</Note>

--- a/iceberg/overview.mdx
+++ b/iceberg/overview.mdx
@@ -51,7 +51,7 @@ WITH (
     table.name = 't1',
     catalog.credential='123456:123456',
     catalog.scope='PRINCIPAL_ROLE:ALL',
-    catalog.oauth2-server-uri='xxx'
+    catalog.oauth2_server_uri='xxx'
     catalog.scope='xxx',
 );
 ```

--- a/iceberg/read-from-iceberg.mdx
+++ b/iceberg/read-from-iceberg.mdx
@@ -1,0 +1,5 @@
+---
+title: "Read data from Iceberg tables"
+sidebarTitle: "Read from Iceberg"
+url: "/ingestion/sources/iceberg"
+---

--- a/iceberg/write-to-iceberg.mdx
+++ b/iceberg/write-to-iceberg.mdx
@@ -1,0 +1,5 @@
+---
+title: "Write data to Iceberg tables"
+sidebarTitle: "Write to Iceberg"
+url: "/integrations/destinations/apache-iceberg"
+---

--- a/ingestion/getting-started/sources.mdx
+++ b/ingestion/getting-started/sources.mdx
@@ -25,7 +25,7 @@ Below is a complete list of source connectors in RisingWave. Click a connector n
 | [Azure Blob](/integrations/sources/azure-blob)   | Latest               |
 | [NATS JetStream](/integrations/sources/nats-jetstream) |                      |
 | [MQTT](/integrations/sources/mqtt)          |                      |
-| [Apache Iceberg](/integrations/sources/apache-iceberg) |                   |
+| [Apache Iceberg](/ingestion/sources/iceberg) |                   |
 | [Load generator](/ingestion/advanced/generate-test-data) | Built-in             |
 
 For information on supported data formats and encodings, and whether you need to use `CREATE SOURCE` or `CREATE TABLE` with each format, see [Data formats and encoding options](/ingestion/getting-started/formats-and-encoding-options).

--- a/ingestion/sources/iceberg-config.mdx
+++ b/ingestion/sources/iceberg-config.mdx
@@ -31,7 +31,12 @@ You don’t need to specify the column names for the Iceberg source, as RisingWa
 
 ## Storage configuration (S3-compatible)
 
+To integrate RisingWave with Iceberg tables stored in S3-compatible object storage, you must provide the necessary connection details. These configurations tell RisingWave exactly where your data warehouse resides and how to authenticate and access it.
+
+### Basic connection
+
 These parameters configure the connection to the underlying S3-compatible storage system where the Iceberg data files are stored. This includes AWS S3, MinIO, and other compatible services.
+
 
 | Parameter             | Description                                                                                                | Required (Conditional)    |
 | :-------------------- | :--------------------------------------------------------------------------------------------------------- | :-------------------------- |
@@ -41,6 +46,18 @@ These parameters configure the connection to the underlying S3-compatible storag
 | `s3.access.key`     | Your S3 access key ID.    | Conditional                     |
 | `s3.secret.key`     | Your S3 secret access key.    | Conditional                    |
 | `s3.path.style.access` | Determines the access style for S3. If `true`, use path-style; if `false`, use [virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html). | No                          |
+
+### AWS S3 Tables integration
+
+RisingWave supports using the Iceberg source with AWS S3 Tables. The following parameters configure the connection to S3 Tables. For more information, see [
+Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
+
+| Parameter             | Description                                                                                                | Required     |
+| :-------------------- | :--------------------------------------------------------------------------------------------------------- | :-------------------------- |
+|`catalog.rest.signing_region` | The signing region when signing requests to the `rest` catalog. | No |
+|`catalog.rest.signing_name` | The signing name when signing requests to the `rest` catalog. | No |
+|`catalog.rest.signing_region` | Specify whether to use SigV4 for signing requests to the `rest` catalog. | No |
+
 
 ## Storage configuration (GCS)
 
@@ -65,9 +82,6 @@ These parameters configure the Iceberg catalog. The catalog is responsible for m
 | `catalog.token`        | A Bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog.                                                         | No                          |
 | `catalog.oauth2_server_uri`   | The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.  | No                          |
 | `catalog.scope`        |  Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog.    | No                    |
-|`catalog.rest.signing_region` | The signing region when signing requests to the `rest` catalog. | No |
-|`catalog.rest.signing_name` | The signing name when signing requests to the `rest` catalog. | No |
-|`catalog.rest.signing_region` | Specify whether to use SigV4 for signing requests to the `rest` catalog. | No |
 | `catalog.jdbc.user`        |  Username for JDBC catalog.                        | No                    |
 | `catalog.jdbc.password`        |   Password for JDBC catalog.                       | No                    |
 

--- a/ingestion/sources/iceberg-config.mdx
+++ b/ingestion/sources/iceberg-config.mdx
@@ -63,8 +63,11 @@ These parameters configure the Iceberg catalog. The catalog is responsible for m
 |`warehouse.path`|    The path of the Iceberg warehouse. Currently, only S3-compatible object storage systems and GCS, are supported. It is required if the `catalog.type` is not `rest`. | Conditional|
 | `catalog.credential` | Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog.                                             | No                          |
 | `catalog.token`        | A Bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog.                                                         | No                          |
-| `catalog.oauth2-server-uri`   | The `oauth2-server-uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.  | No                          |
+| `catalog.oauth2_server_uri`   | The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.  | No                          |
 | `catalog.scope`        |  Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog.    | No                    |
+|`catalog.rest.signing_region` | The signing region when signing requests to the `rest` catalog. | No |
+|`catalog.rest.signing_name` | The signing name when signing requests to the `rest` catalog. | No |
+|`catalog.rest.signing_region` | Specify whether to use SigV4 for signing requests to the `rest` catalog. | No |
 | `catalog.jdbc.user`        |  Username for JDBC catalog.                        | No                    |
 | `catalog.jdbc.password`        |   Password for JDBC catalog.                       | No                    |
 

--- a/integrations/destinations/apache-iceberg.mdx
+++ b/integrations/destinations/apache-iceberg.mdx
@@ -67,14 +67,20 @@ RisingWave converts RisingWave data types from/to Iceberg according to the follo
 | RisingWave Type | Iceberg Type |
 | :------------- | :---------- |
 | boolean | boolean |
-| int | integer |
+| int | int |
+| smallint | int |
 | bigint | long |
 | real | float |
+| float | float|
 | double | double |
 | varchar | string |
 | date | date |
 | timestamptz | timestamptz |
 | timestamp | timestamp |
+| map | map |
+| array | list| 
+| struct | struct| 
+| jsonb | string|
 
 ## Catalog
 

--- a/integrations/destinations/apache-iceberg.mdx
+++ b/integrations/destinations/apache-iceberg.mdx
@@ -21,6 +21,8 @@ WITH (
 
 ## Parameters
 
+### Basic parameters
+
 | Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | type                         | Required. Allowed values: `append-only` and `upsert`.                                                                                                                                                                                                                                                                                                                                                                                                        |
@@ -44,6 +46,14 @@ WITH (
 | catalog.token| Optional. A bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |
 | catalog.oauth2_server_uri | Optional. The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
 | catalog.scope | Optional. Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog. |
+
+### AWS S3 Tables integration
+
+RisingWave supports using the Iceberg sink with AWS S3 Tables. Configure the following parameters to integrate with S3 Tables. For more information, see [
+Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
+
+| Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
 | catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
 | catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |

--- a/integrations/destinations/apache-iceberg.mdx
+++ b/integrations/destinations/apache-iceberg.mdx
@@ -42,8 +42,11 @@ WITH (
 | create_table_if_not_exists | Optional. When set to `true`, it will automatically create a table for the Iceberg sink. |
 | catalog.credential | Optional. Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog.|
 | catalog.token| Optional. A bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |
-| catalog.oauth2-server-uri | Optional. The `oauth2-server-uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
+| catalog.oauth2_server_uri | Optional. The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
 | catalog.scope | Optional. Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog. |
+| catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
+| catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
+| catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |
 
 ## Data type mapping
 
@@ -109,7 +112,7 @@ WITH (
     table.name = 't1',
     catalog.credential='123456:123456',
     catalog.scope='PRINCIPAL_ROLE:ALL',
-    catalog.oauth2-server-uri='xxx'
+    catalog.oauth2_server_uri='xxx'
     catalog.scope='xxx',
 );
 ```

--- a/integrations/destinations/apache-iceberg.mdx
+++ b/integrations/destinations/apache-iceberg.mdx
@@ -1,8 +1,11 @@
 ---
 title: "Sink data from RisingWave to Apache Iceberg"
-description: "This guide describes how to sink data from RisingWave to Apache Iceberg using the Iceberg sink connector in RisingWave. Apache Iceberg is a table format designed to support huge tables. For more information, see [Apache Iceberg](https://iceberg.apache.org)."
+description: "This guide describes how to sink data from RisingWave to Apache Iceberg using the Iceberg sink connector in RisingWave."
 sidebarTitle: Apache Iceberg
 ---
+In RisingWave, you can stream data into Iceberg tables with the built-in Iceberg sink connector.
+
+Apache Iceberg is a table format designed to support huge tables. For more information, see [Apache Iceberg](https://iceberg.apache.org).
 
 ## Prerequisites
 * Ensure you already have an Iceberg table that you can sink data to. For additional guidance on creating a table and setting up Iceberg, refer to this [quickstart guide](https://iceberg.apache.org/spark-quickstart/) on creating an Iceberg table.
@@ -23,37 +26,36 @@ WITH (
 
 ### Basic parameters
 
-| Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| type                         | Required. Allowed values: `append-only` and `upsert`.                                                                                                                                                                                                                                                                                                                                                                                                        |
-| force_append_only          | Optional. If true, forces the sink to be append-only, even if it cannot be.                                                                                                                                                                                                                                                                                                                                                                             |
-| s3.endpoint                  | Optional. Endpoint of the S3. <ul><li>For MinIO object store backend, it should be `http://${MINIO_HOST}:${MINIO_PORT}`. </li><li>For AWS S3, refer to [S3](https://docs.aws.amazon.com/general/latest/gr/s3.html). </li></ul>                                                                                                                                                                                                                                                      |
-| s3.region                    | Optional. The region where the S3 bucket is hosted. Either s3.endpoint or s3.region must be specified.                                                                                                                                                                                                                                                                                                                                                  |
-| s3.access.key                | Required. Access key of the S3 compatible object store.                                                                                                                                                                                                                                                                                                                                                                                                 |
-| s3.secret.key                | Required. Secret key of the S3 compatible object store.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| Parameter Names | Description |
+| :------------- | :---------- |
+| type | Required. Allowed values: `append-only` and `upsert`. |
+| force_append_only | Optional. If true, forces the sink to be append-only, even if it cannot be. |
+| s3.endpoint | Optional. Endpoint of the S3. <ul><li>For MinIO object store backend, it should be `http://${MINIO_HOST}:${MINIO_PORT}`. </li><li>For AWS S3, refer to [S3](https://docs.aws.amazon.com/general/latest/gr/s3.html). </li></ul> |
+| s3.region | Optional. The region where the S3 bucket is hosted. Either s3.endpoint or s3.region must be specified. |
+| s3.access.key | Required. Access key of the S3 compatible object store. |
+| s3.secret.key | Required. Secret key of the S3 compatible object store. |
 | s3.path.style.access | Optional. Determines the access style for S3. If `true`, use path-style; if `false`, use [virtual-hosted–style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html). |
-| database.name                | Required. The database of the target Iceberg table.                                                                                                                                                                                                                                                                                                                                                                                                     |
-| table.name                   | Required. The name of the target Iceberg table.                                                                                                                                                                                                                                                                                                                                                                                                         |
-| catalog.name                 | Conditional. The name of the Iceberg catalog. It can be omitted for storage catalog but required for other catalogs.                                                                                                                                                                                                                                                                                                                                    |
-| catalog.type                 | Optional. The catalog type used in this table. Currently, the supported values are storage, rest, hive, jdbc, and glue. If not specified, storage is used. For details, see [Catalogs](#catalogs).                                                                                                                                                                                                                                                      |
-| warehouse.path               | Conditional. The path of the Iceberg warehouse. Currently, only S3-compatible object storage systems, such as AWS S3 and MinIO, are supported. It's required if the `catalog.type` is not rest.                                                                                                                                                                                                                                                           |
-| catalog.url                  | Conditional. The URL of the catalog. It is required when `catalog.type` is not storage.                                                                                                                                                                                                                                                                                                                                                                   |
-| primary_key                 | The primary key for an upsert sink. It is only applicable to the upsert mode.                                                                                                                                                                                                                                                                                                                                                                           |
-| partition_by | Optional. Specify partitioning using column names or transformations. Supported formats include: `column`, `transform(column)`, `transform(n,column)`, and `transform(n, column)`. Transformations can include functions like `bucket` or `truncate`, where `n` is an optional parameter. Ensure that the specified partition fields exist in the schema.   |
-| commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 10. <br/>The behavior of this field also depends on the `sink_decouple` setting:<ul><li>If `sink_decouple` is true (the default), the default value of `commit_checkpoint_interval` is 10.</li> <li>If `sink_decouple` is set to false, the default value of `commit_checkpoint_interval` is 1.</li> <li>If `sink_decouple` is set to false and `commit_checkpoint_interval` is set to larger than 1, an error will occur.</li></ul>|
+| database.name | Required. The database of the target Iceberg table. |
+| table.name | Required. The name of the target Iceberg table. |
+| catalog.name | Conditional. The name of the Iceberg catalog. It can be omitted for storage catalog but required for other catalogs. |
+| catalog.type | Optional. The catalog type used in this table. Currently, the supported values are storage, rest, hive, jdbc, and glue. If not specified, storage is used. For details, see [Catalogs](#catalogs). |
+| warehouse.path | Conditional. The path of the Iceberg warehouse. Currently, only S3-compatible object storage systems, such as AWS S3 and MinIO, are supported. It's required if the `catalog.type` is not rest. |
+| catalog.url | Conditional. The URL of the catalog. It is required when `catalog.type` is not storage. |
+| primary_key | The primary key for an upsert sink. It is only applicable to the upsert mode. |
+| partition_by | Optional. Specify partitioning using column names or transformations. Supported formats include: `column`, `transform(column)`, `transform(n,column)`, and `transform(n, column)`. Transformations can include functions like `bucket` or `truncate`, where `n` is an optional parameter. Ensure that the specified partition fields exist in the schema. |
+| commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 10. <br/>The behavior of this field also depends on the `sink_decouple` setting:<ul><li>If `sink_decouple` is true (the default), the default value of `commit_checkpoint_interval` is 10.</li> <li>If `sink_decouple` is set to false, the default value of `commit_checkpoint_interval` is 1.</li> <li>If `sink_decouple` is set to false and `commit_checkpoint_interval` is set to larger than 1, an error will occur.</li></ul> |
 | create_table_if_not_exists | Optional. When set to `true`, it will automatically create a table for the Iceberg sink. |
-| catalog.credential | Optional. Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog.|
-| catalog.token| Optional. A bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |
-| catalog.oauth2_server_uri | Optional. The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
+| catalog.credential | Optional. Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog. |
+| catalog.token | Optional. A bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |
+| catalog.oauth2_server_uri | Optional. The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog. |
 | catalog.scope | Optional. Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog. |
 
 ### AWS S3 Tables integration
 
-RisingWave supports using the Iceberg sink with AWS S3 Tables. Configure the following parameters to integrate with S3 Tables. For more information, see [
-Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
+RisingWave supports using the Iceberg sink with AWS S3 Tables. Configure the following parameters to integrate with S3 Tables. For more information, see [Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
 
-| Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Parameter Names | Description |
+| :------------- | :---------- |
 | catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
 | catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
 | catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |
@@ -63,16 +65,16 @@ Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-wit
 RisingWave converts RisingWave data types from/to Iceberg according to the following data type mapping table:
 
 | RisingWave Type | Iceberg Type |
-| :-------------- | :----------- |
-| boolean         | boolean      |
-| int             | integer      |
-| bigint          | long         |
-| real            | float        |
-| double          | double       |
-| varchar         | string       |
-| date            | date         |
-| timestamptz     | timestamptz  |
-| timestamp       | timestamp    |
+| :------------- | :---------- |
+| boolean | boolean |
+| int | integer |
+| bigint | long |
+| real | float |
+| double | double |
+| varchar | string |
+| date | date |
+| timestamptz | timestamptz |
+| timestamp | timestamp |
 
 ## Catalog
 

--- a/integrations/sources/apache-iceberg.mdx
+++ b/integrations/sources/apache-iceberg.mdx
@@ -35,7 +35,7 @@ You don’t need to specify the column name for the Iceberg source, as RisingWav
 | catalog.url    | Conditional. The URL of the catalog. It is required when `catalog.type` is not `storage`.                                                                                                               |
 | catalog.credential | Optional. Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog.|
 | catalog.token| Optional. A Bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |
-| catalog.oauth2-server-uri | Optional. The `oauth2-server-uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
+| catalog.oauth2_server_uri | Optional. The `oauth2_server_uri` for accessing the Iceberg catalog, serving as the token endpoint URI to fetch a token if the `rest` catalog is not the authorization server. Applicable only in the `rest` catalog.|
 | catalog.scope | Optional. Scope for accessing the Iceberg catalog, providing additional scope for OAuth2. Applicable only in the `rest` catalog. |
 | commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 60.|
 
@@ -94,7 +94,7 @@ WITH (
     table.name = 't1',
     catalog.credential='123456:123456',
     catalog.scope='PRINCIPAL_ROLE:ALL',
-    catalog.oauth2-server-uri='xxx'
+    catalog.oauth2_server_uri='xxx'
     catalog.scope='xxx',
 );
 ```

--- a/mint.json
+++ b/mint.json
@@ -443,7 +443,8 @@
       "pages": [
         "iceberg/overview",
         "iceberg/read-from-iceberg",
-        "iceberg/write-to-iceberg"
+        "iceberg/write-to-iceberg",
+        "iceberg/iceberg-table-engine"
       ]
     },
     {
@@ -606,6 +607,13 @@
             "serve/risingwave-as-postgres-fdw",
             "serve/subscription"
           ]
+        },
+        {
+          "group": "Store data",
+          "pages": [
+            "store/overview",
+            "store/iceberg-table-engine"
+          ] 
         },
         {
           "group": "Deliver data",

--- a/mint.json
+++ b/mint.json
@@ -588,6 +588,13 @@
           ]
         },
         {
+          "group": "Store data",
+          "pages": [
+            "store/overview",
+            "store/iceberg-table-engine"
+          ] 
+        },
+        {
           "group": "Serve data",
           "pages": [
             "serve/overview",
@@ -607,13 +614,6 @@
             "serve/risingwave-as-postgres-fdw",
             "serve/subscription"
           ]
-        },
-        {
-          "group": "Store data",
-          "pages": [
-            "store/overview",
-            "store/iceberg-table-engine"
-          ] 
         },
         {
           "group": "Deliver data",

--- a/mint.json
+++ b/mint.json
@@ -82,7 +82,7 @@
     },
     "body": {
       "family": "Monument Grotesk",
-      "weight": 300,
+      "weight": 400,
       "url": "https://fonts.gstatic.com/s/inter/v18/UcCo3FwrK3iLTcviYwYZ8UA3.woff2",
       "format": "woff2"
     }

--- a/mint.json
+++ b/mint.json
@@ -67,6 +67,10 @@
     {
       "name": "Changelog",
       "url": "changelog"
+    },
+    {
+      "name": "Iceberg",
+      "url": "iceberg"
     }
   ],
   "font": {
@@ -78,7 +82,7 @@
     },
     "body": {
       "family": "Monument Grotesk",
-      "weight": 400,
+      "weight": 300,
       "url": "https://fonts.gstatic.com/s/inter/v18/UcCo3FwrK3iLTcviYwYZ8UA3.woff2",
       "format": "woff2"
     }
@@ -432,6 +436,14 @@
         "client-libraries/python",
         "client-libraries/ruby",
         "client-libraries/java"
+      ]
+    },
+    {
+      "group": "Iceberg",
+      "pages": [
+        "iceberg/overview",
+        "iceberg/read-from-iceberg",
+        "iceberg/write-to-iceberg"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -57,6 +57,10 @@
       "url": "sql"
     },
     {
+      "name": "Iceberg",
+      "url": "iceberg"
+    },
+    {
       "name": "Python SDK",
       "url": "python-sdk"
     },
@@ -67,10 +71,6 @@
     {
       "name": "Changelog",
       "url": "changelog"
-    },
-    {
-      "name": "Iceberg",
-      "url": "iceberg"
     }
   ],
   "font": {

--- a/sql/commands/sql-create-connection.mdx
+++ b/sql/commands/sql-create-connection.mdx
@@ -3,7 +3,11 @@ title: "CREATE CONNECTION"
 description: "Use the `CREATE CONNECTION` command to create a reusable catalog for connector parameters."
 ---
 
-The `CREATE CONNECTION` command creates a reusable connection configuration that can be referenced when creating sources, sinks, or tables. Currently supported connection types are Kafka and schema registry.
+The `CREATE CONNECTION` command creates a reusable connection configuration that can be referenced when creating sources, sinks, or tables. Currently supported connection types are Kafka, Schema Registry, and Iceberg.
+
+<Note>
+Added in v2.3: Support `iceberg` connection.
+</Note>
 
 ## Syntax
 
@@ -16,26 +20,23 @@ WITH (
 );
 ```
 
-Connection parameters can reference secrets using the `SECRET` keyword. This allows sensitive information to be stored securely and referenced in the connection configuration. Additionally, changes to the secret are automatically applied, so there's no need to alter the connection.
-
-
 ## Parameter
 
 | Parameter or clause | Description                                                                                                                      |
 | :------------------ | :------------------------------------------------------------------------------------------------------------------------------- |
-| `type` | Required. The type of connection. Supported values: `kafka`, `schema_registry`, `iceberg`. |
-| `properties.bootstrap.server` | The Kafka bootstrap server addresses. Required when `type` is `kafka`. |
-
-<Note>
-Added in v2.3: Support `iceberg` connection.
-</Note>
+| type | Required. The type of connection. Supported values: `kafka`, `schema_registry`, `iceberg`. |
+| secret_name | Use the `SECRET` keyword to reference secrets, allowing sensitive information to be stored securely and referenced in the connection configuration. Changes to the secret are automatically applied, so there's no need to alter the connection. |
 
 
 <Accordion title="Click to see all supported properties for Kafka connection.">
 
-The following properties are optional and can be included in the Kafka connection configuration as needed:
+**Required**
 
- **SSL/SASL authentication:**
+- `properties.bootstrap.server`: The Kafka bootstrap server addresses.
+ 
+**Optional**
+
+For SSL/SASL authentication:
   - `properties.security.protocol`
   - `properties.ssl.endpoint.identification.algorithm`
   - `properties.ssl.ca.location`
@@ -55,11 +56,11 @@ The following properties are optional and can be included in the Kafka connectio
   - `properties.sasl.kerberos.min.time.before.relogin`
   - `properties.sasl.oauthbearer.config`
 
- **PrivateLink connection:**
+For PrivateLink connection:
   - `privatelink.targets`
   - `privatelink.endpoint`
 
- **AWS authentication:**
+For AWS authentication:
   - `aws.region`
   - `endpoint`
   - `aws.credentials.access_key_id`
@@ -67,6 +68,16 @@ The following properties are optional and can be included in the Kafka connectio
   - `aws.credentials.session_token`
   - `aws.credentials.role.arn`
   - `aws.credentials.role.external_id`
+</Accordion>
+
+<Accordion title="Click to see all supported properties for Schema Registry.">
+
+| Property name                  | Description |
+|:-------------------------------|:------------|
+| schema.registry                  | The base URL of the Schema Registry service. |
+| schema.registry.username         | The username for authenticating to the Schema Registry service. |
+| schema.registry.password         | The password for authenticating to the Schema Registry service. |
+
 </Accordion>
 
 <Accordion title="Click to see all supported properties for Iceberg connection.">

--- a/sql/commands/sql-create-connection.mdx
+++ b/sql/commands/sql-create-connection.mdx
@@ -90,13 +90,16 @@ For AWS authentication:
 | s3.access.key                 | AWS S3 access key. |
 | s3.secret.key                 | AWS S3 secret key. |
 | gcs.credential                | Google Cloud Storage credential. |
-| warehouse.path                | Path of the Iceberg warehouse, applicable only in storage catalog. |
-| catalog.name                  | Name of the catalog, optional for storage catalog, required for others. |
-| catalog.uri                   | URI of the Iceberg catalog, applicable only in REST catalog. |
-| catalog.credential            | Credential for accessing Iceberg catalog, applicable only in REST catalog. |
-| catalog.token                 | Token for interacting with REST catalog server. |
-| catalog.oauth2-server-uri     | OAuth2 token endpoint URI, applicable only in REST catalog. |
-| catalog.scope                 | Additional OAuth2 scope for accessing the Iceberg catalog, applicable only in REST catalog. |
+| warehouse.path                | Path of the Iceberg warehouse, applicable only in `storage` catalog. |
+| catalog.name                  | Name of the catalog, optional for `storage` catalog, required for others. |
+| catalog.uri                   | URI of the Iceberg catalog, applicable only in `rest` catalog. |
+| catalog.credential            | Credential for accessing Iceberg catalog, applicable only in `rest` catalog. |
+| catalog.token                 | Token for interacting with `rest` catalog server. |
+| catalog.oauth2_server_uri     | OAuth2 token endpoint URI, applicable only in `rest` catalog. |
+| catalog.scope                 | Additional OAuth2 scope for accessing the Iceberg catalog, applicable only in `rest` catalog. |
+| catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
+| catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
+| catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |
 | s3.path.style.access          | Enables path-style access for AWS S3. |
 | catalog.jdbc.user             | JDBC user for catalog access. |
 | catalog.jdbc.password         | JDBC password for catalog access. |

--- a/store/iceberg-table-engine.mdx
+++ b/store/iceberg-table-engine.mdx
@@ -1,11 +1,22 @@
 ---
 title: "Iceberg table engine"
-description: Learn how to use Iceberg table engine in RisingWave.
+description: "Learn how to use the Iceberg table engine in RisingWave to store data natively in the Iceberg format."
 ---
 
-RisingWave supports using Iceberg table engine to manage Iceberg table in your catalog and Cloud storage. Follow the steps below to set up Iceberg configurations and create your table with Iceberg engine.
+In RisingWave, the Iceberg table engine allows you to create and manage tables directly within the system, while storing their underlying data in the Apache Iceberg format on external object storage. This offers an alternative way to persist data compared to RisingWave's default row-based internal storage format (which also typically uses object storage).
 
-## 1. Create an Iceberg connection
+Using the Iceberg table engine provides several benefits:
+
+- Native management: RisingWave manages the table's lifecycle (creation, schema, writes). You interact with it like any other RisingWave table (querying, inserting, using in materialized views).
+- Iceberg format storage: Data is physically stored according to the Iceberg specification, using a configured Iceberg catalog and object storage path. This ensures compatibility with the Iceberg ecosystem.
+- Simplified pipelines: You don't need a separate CREATE SINK step to export data out of RisingWave into Iceberg format if Iceberg is your desired end format managed by RisingWave. Data ingested or computed can land directly in these Iceberg tables.
+- Interoperability: Tables created with the Iceberg engine are standard Iceberg tables and can be read by external Iceberg-compatible query engines (like Spark, Trino, Flink, Dremio) using the same catalog and storage configuration.
+
+This guide details how to set up and use the Iceberg table engine.
+
+## Setup and usage
+
+### 1. Create an Iceberg connection
 
 The Iceberg connection contains information about catalog and object storage. For syntax and properties, see [`CREATE CONNECTION`](/sql/commands/sql-create-connection#syntax).
 
@@ -22,14 +33,6 @@ CREATE CONNECTION public.conn WITH (
     s3.access.key = 'hummockadmin',
     s3.secret.key = 'hummockadmin'
 );
-```
-
-To protect your access key and secret key, you can use `SECRET` to provide your sensitive credentials.
-
-```sql Use SECRET
-CREATE SECRET secret_1 WITH (
-  backend = 'meta'
-) AS 'hummockadmin';
 ```
 
 The following examples show how to create an Iceberg connection using different catalog types.
@@ -75,18 +78,20 @@ CREATE CONNECTION public.conn WITH (
 );
 ```
 
-## 2. Configure connection
+### 2. Configure the engine to use the connection
 
-Configure the connection for Iceberg table engine, so Iceberg table created in the next step can use the connection by default.
+You need to configure the iceberg table engine to use the connection that was just created. All tables created with the Iceberg table engine will use the connection by default.
 
 ```sql
 SET iceberg_engine_connection = 'public.conn';
 ALTER system SET iceberg_engine_connection = 'public.conn';
 ```
 
-## 3. Create table with Iceberg engine
+## 3. Create a table with the Iceberg engine
 
-Suppose creating a table with `commit_checkpoint_interval = 1`. It means RisingWave will commit changes to the iceberg table at every checkpoint. Typically, the checkpoint time is 1s. 
+Now, you can create a table using the standard `CREATE TABLE` syntax, but adding the `ENGINE = iceberg` clause.
+
+The `commit_checkpoint_interval` parameter controls how frequently (every N checkpoints) RisingWave commits changes to the Iceberg table, creating a new Iceberg snapshot. The default value is 60. Typically, the checkpoint time is 1s. That means RisingWave will commit changes to the Iceberg table every 60s.
 
 ```sql
 CREATE TABLE t (
@@ -97,89 +102,79 @@ ENGINE = iceberg;
 
 ```
 
-## 4. Insert rows
+## 4. Basic operations (insert and select)
+
+For tables created with the Iceberg table engine, you can insert data using standard `INSERT` statements and query using `SELECT`. You can use them as base tables to create materialized views or join them with regular tables. However, RisingWave doesn't support renaming or changing the schemas of natively managed Iceberg tables.
 
 ```sql
-INSERT INTO t VALUES (1, 'xxx');
+INSERT INTO users_iceberg VALUES (1, 'Alice', NOW());
+INSERT INTO users_iceberg VALUES (2, 'Bob', NOW());
+
+SELECT * FROM users_iceberg WHERE user_id = 1;
+--  user_id | user_name |         signup_ts
+-- ---------+-----------+---------------------------
+--        1 | Alice     | 2023-10-27 10:30:00.123...
+-- (1 row)
 ```
 
-## 5. Query Iceberg table
+## 5. Streaming ingestion into Iceberg tables
+
+You can define a source connector directly within the CREATE TABLE statement that uses the Iceberg engine. Data flows from the external source (e.g., Kafka, Pulsar) directly into the Iceberg table format managed by RisingWave.
 
 ```sql
-SELECT * FROM t;
- id | name  
-----+------  
-  1 | xxx  
-(1 row)  
-
-```
-
-## 6. Streaming ingestion
-
-You can streaming ingest data to the iceberg table in a RisingWave familiar way.
-
-<Note>
-The configuration `commit_checkpoint_interval=N` for streaming ingestion. RisingWave streaming ingests data into the iceberg table and commits every N checkpoint. To mitigate the small files problem, we recommend using `commit_checkpoint_interval=60` which is the default value. Typically, if checkpoint happens every 1s, then it means we commit to iceberg table every 60s.
-</Note>
-
-You can define a connector in the table together with an iceberg engine. For example, if you use kafka connector, the table would continuously ingest data into table Iceberg table from Kafka.
-
-```sql
-CREATE TABLE t2 (
-    v1 INT, 
-    v2 VARCHAR
+-- Example: Stream Kafka topic directly into an Iceberg table
+CREATE TABLE page_views_iceberg (
+    view_id BIGINT,
+    url VARCHAR,
+    user_id INT,
+    view_ts TIMESTAMP
 ) WITH (
     connector = 'kafka',
-    topic = 'kafka_1_partition_topic',
-    properties.bootstrap.server = '127.0.0.1:9092',
-    scan.startup.mode = 'earliest'
-) 
-FORMAT PLAIN ENCODE JSON 
-ENGINE = iceberg;
+    topic = 'page_views_topic',
+    properties.bootstrap.server = 'kafka:9092',
+    scan.startup.mode = 'earliest',
+    commit_checkpoint_interval = 120 -- Commit every 120 checkpoints (e.g., ~2 mins)
+)
+FORMAT PLAIN ENCODE JSON  -- Specify the format of the incoming Kafka messages
+ENGINE = iceberg;        -- Store data natively in Iceberg format
 ```
 
-You can also use `Sink into table` to ingest data into Iceberg table as well.
-
-## 7. Cleanup
+You can also sink data from another RisingWave source, table, or materialized view into a table created with the Iceberg engine.
 
 ```sql
-DROP TABLE t;
+-- Assume users_iceberg table exists (created with ENGINE = iceberg)
+-- Assume raw_users_stream source exists
+
+CREATE SINK user_sink INTO users_iceberg FROM raw_users_stream;
 ```
 
-## Related topics
-
-This section introduces additional features and considerations when using Iceberg tables in RisingWave.
-
-### AWS S3 Tables integration
-
-RisingWave supports using the Iceberg table engine with AWS S3 Tables. Configure the following parameters to integrate with S3 Tables. For more information, see [
-Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
-
-| Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
-| catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
-| catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |
+## Features and considerations
 
 ### Time travel
 
-You can run a time travel query on an Iceberg table to retrieve historical data based on a specific timestamp or snapshot ID.
+Iceberg's snapshotting mechanism enables time travel queries. You can query the state of the table as of a specific timestamp or snapshot ID using the `FOR SYSTEM_TIME AS OF` or `FOR SYSTEM_VERSION AS OF` clauses.
 
 ```sql
--- timestamp
-SELECT * FROM t FOR SYSTEM_TIME AS OF '2025-02-10 11:48:06'; 
+-- Query state based on timestamp
+SELECT * FROM users_iceberg FOR SYSTEM_TIME AS OF '2023-10-27 10:00:00';
 
--- snapshot id
-SELECT * FROM t FOR SYSTEM_VERSION AS OF 1839661944842368408;  
+-- Query state based on a specific Iceberg snapshot ID
+SELECT * FROM users_iceberg FOR SYSTEM_VERSION AS OF 876543219876543210; -- Replace with actual snapshot ID
 ```
 
-### External Access
+### External access
 
-If an external system needs to access an Iceberg table created by RisingWave, it can reuse the Iceberg connection information from Step 1.
+Since the data is stored in the standard Iceberg format, external systems (like Spark, Trino, Dremio) can directly query the tables created by RisingWave's Iceberg engine. To do this, configure the external system with the same Iceberg connection details used in RisingWave:
 
-For example, to access the table `t` in the public schema, the corresponding namespace in the Iceberg catalog is also `public`, and the table name remains `t`.
+- Catalog type (`storage`, `jdbc`, `glue`, `rest`)
+- Catalog configuration (URI, warehouse path, credentials)
+- Object storage configuration (endpoint, credentials)
 
-## Limitation
+The namespace and table name in the external catalog will typically match the schema and table name in RisingWave. For example, the table `public.users_iceberg` in RisingWave would be accessed as table `users_iceberg` within the public namespace/database in the configured Iceberg catalog by an external tool.
 
-Currently, there is no compaction service running for the Iceberg table, so you need to run compaction manually. We are working on this feature and plan to release it in a future version.
+## Limitations
+
+RisingWave does not currently have a built-in automatic compaction service for tables created with the Iceberg engine. Streaming ingestion, especially with frequent commits (low `commit_checkpoint_interval`), can lead to many small files. You may need to run compaction procedures manually using external tools that operate on Iceberg tables to optimize read performance. We are actively working on integrating compaction features.
+
+
 

--- a/store/iceberg-table-engine.mdx
+++ b/store/iceberg-table-engine.mdx
@@ -1,0 +1,174 @@
+---
+title: "Iceberg table engine"
+description: Learn how to use Iceberg table engine in RisingWave.
+---
+
+RisingWave supports using Iceberg table engine to manage Iceberg table in your catalog and Cloud storage. Follow the steps below to set up Iceberg configurations and create your table with Iceberg engine.
+
+## 1. Create an Iceberg connection
+
+The Iceberg connection contains information about catalog and object storage. For syntax and properties, see [`CREATE CONNECTION`](/sql/commands/sql-create-connection#syntax).
+
+The example below creates an Iceberg connection `conn` using `storage` as catalog and `MinIO` as an S3-compatible object store.
+
+```sql Storage catalog
+CREATE CONNECTION public.conn WITH (
+    type = 'iceberg',
+    catalog.name = 'demo',
+    catalog.type = 'storage',
+    warehouse.path = 's3://hummock001/iceberg-data',
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'ap-southeast-2',
+    s3.access.key = 'hummockadmin',
+    s3.secret.key = 'hummockadmin'
+);
+```
+
+To protect your access key and secret key, you can use `SECRET` to provide your sensitive credentials.
+
+```sql Use SECRET
+CREATE SECRET secret_1 WITH (
+  backend = 'meta'
+) AS 'hummockadmin';
+```
+
+The following examples show how to create an Iceberg connection using different catalog types.
+
+```sql JDBC catalog
+CREATE CONNECTION public.conn WITH (
+    type = 'iceberg',
+    warehouse.path = 's3://hummock001/iceberg-data',
+    s3.access.key = secret secret_1,
+    s3.secret.key = secret secret_1,
+    s3.endpoint = 'http://127.0.0.1:9301',
+    s3.region = 'ap-southeast-2',
+    catalog.type = 'jdbc',
+    catalog.uri = 'jdbc:postgresql://127.0.0.1:8432/metadata',
+    catalog.jdbc.user = 'postgres',
+    catalog.jdbc.password = '123',
+    catalog.name = 'dev',
+);
+```
+
+```sql Glue catalog
+CREATE CONNECTION public.conn WITH (
+    type = 'iceberg',
+    catalog.type = 'glue',
+    warehouse.path = 's3://my-iceberg-bucket/test',
+    s3.endpoint = 'https://s3.ap-southeast-2.amazonaws.com',
+    s3.region = 'ap-southeast-2',
+    s3.access.key = secret secret_1,
+    s3.secret.key = secret secret_1,
+);
+```
+
+```sql Rest catalog
+CREATE CONNECTION public.conn WITH (
+    type = 'iceberg',
+    catalog.type='rest',
+    catalog.uri= 'http://localhost:8181/catalog',
+    warehouse.path = 'test',
+    s3.endpoint = 'https://s3.ap-southeast-2.amazonaws.com',
+    s3.region = 'ap-southeast-2'
+    s3.access.key = secret secret_1,
+    s3.secret.key = secret secret_1
+);
+```
+
+## 2. Configure connection
+
+Configure the connection for Iceberg table engine, so Iceberg table created in the next step can use the connection by default.
+
+```sql
+SET iceberg_engine_connection = 'public.conn';
+ALTER system SET iceberg_engine_connection = 'public.conn';
+```
+
+## 3. Create table with Iceberg engine
+
+Suppose creating a table with `commit_checkpoint_interval = 1`. It means RisingWave will commit changes to the iceberg table at every checkpoint. Typically, the checkpoint time is 1s. 
+
+```sql
+CREATE TABLE t (
+    id INT PRIMARY KEY, 
+    name VARCHAR
+) WITH (commit_checkpoint_interval = 1) 
+ENGINE = iceberg;
+
+```
+
+## 4. Insert rows
+
+```sql
+INSERT INTO t VALUES (1, 'xxx');
+```
+
+## 5. Query Iceberg table
+
+```sql
+SELECT * FROM t;
+ id | name  
+----+------  
+  1 | xxx  
+(1 row)  
+
+```
+
+## 6. Streaming ingestion
+
+You can streaming ingest data to the iceberg table in a RisingWave familiar way.
+
+<Note>
+The configuration `commit_checkpoint_interval=N` for streaming ingestion. RisingWave streaming ingests data into the iceberg table and commits every N checkpoint. To mitigate the small files problem, we recommend using `commit_checkpoint_interval=60` which is the default value. Typically, if checkpoint happens every 1s, then it means we commit to iceberg table every 60s.
+</Note>
+
+You can define a connector in the table together with an iceberg engine. For example, if you use kafka connector, the table would continuously ingest data into table Iceberg table from Kafka.
+
+```sql
+CREATE TABLE t2 (
+    v1 INT, 
+    v2 VARCHAR
+) WITH (
+    connector = 'kafka',
+    topic = 'kafka_1_partition_topic',
+    properties.bootstrap.server = '127.0.0.1:9092',
+    scan.startup.mode = 'earliest'
+) 
+FORMAT PLAIN ENCODE JSON 
+ENGINE = iceberg;
+```
+
+You can also use `Sink into table` to ingest data into Iceberg table as well.
+
+## 7. Cleanup
+
+```sql
+DROP TABLE t;
+```
+
+## Related topics
+
+This section introduces additional features and considerations when using Iceberg tables in RisingWave.
+
+### Time travel
+
+You can run a time travel query on an Iceberg table to retrieve historical data based on a specific timestamp or snapshot ID.
+
+```sql
+-- timestamp
+SELECT * FROM t FOR SYSTEM_TIME AS OF '2025-02-10 11:48:06'; 
+
+-- snapshot id
+SELECT * FROM t FOR SYSTEM_VERSION AS OF 1839661944842368408;  
+```
+
+### External Access
+
+If an external system needs to access an Iceberg table created by RisingWave, it can reuse the Iceberg connection information from Step 1.
+
+For example, to access the table `t` in the public schema, the corresponding namespace in the Iceberg catalog is also `public`, and the table name remains `t`.
+
+## Limitation
+
+Currently, there is no compaction service running for the Iceberg table, so you need to run compaction manually. We are working on this feature and plan to release it in a future version.
+

--- a/store/iceberg-table-engine.mdx
+++ b/store/iceberg-table-engine.mdx
@@ -150,6 +150,17 @@ DROP TABLE t;
 
 This section introduces additional features and considerations when using Iceberg tables in RisingWave.
 
+### AWS S3 Tables integration
+
+RisingWave supports using the Iceberg table engine with AWS S3 Tables. Configure the following parameters to integrate with S3 Tables. For more information, see [
+Integrate Iceberg with Amazon S3 Tables](/iceberg/overview#integrate-iceberg-with-amazon-s3-tables).
+
+| Parameter Names              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| catalog.rest.signing_region | The signing region when signing requests to the `rest` catalog. |
+| catalog.rest.signing_name | The signing name when signing requests to the `rest` catalog. |
+| catalog.rest.signing_region | Specify whether to use SigV4 for signing requests to the `rest` catalog. |
+
 ### Time travel
 
 You can run a time travel query on an Iceberg table to retrieve historical data based on a specific timestamp or snapshot ID.

--- a/store/overview.mdx
+++ b/store/overview.mdx
@@ -1,0 +1,16 @@
+---
+title: "Overview"
+description: Learn how to store data persistently inside RisingWave.
+---
+
+This topic explains how to store data in RisingWave. Whenever you create either a materialized view or a table, RisingWave will persist the internal data inside object store (e.g., Amazon S3).
+
+RisingWave offers two types of storages: row-based storage (default), and columnar-based storage (Apache Iceberg).
+
+## Row-based storage
+
+By default, tables and materialized views are stored in row-based storage, using a specialized storage engine called [Hummock](https://risingwave.com/blog/hummock-a-storage-engine-designed-for-stream-processing/). The row-based storage will automatically cache data in local memory in order to get optimal storage. The row-based storage is good at serving ad-hoc point and short-range access. But it’s not optimized for long-range access and full-table scans.
+
+## Columnar-based storage
+
+RisingWave offers columnar-based storage. Instead of using proprietary format, RisingWave stores analytical data based on Apache Iceberg. For more details, see [Iceberg table engine](/serve/iceberg-table-engine).

--- a/store/overview.mdx
+++ b/store/overview.mdx
@@ -13,4 +13,4 @@ By default, tables and materialized views are stored in row-based storage, using
 
 ## Columnar-based storage
 
-RisingWave offers columnar-based storage. Instead of using proprietary format, RisingWave stores analytical data based on Apache Iceberg. For more details, see [Iceberg table engine](/serve/iceberg-table-engine).
+RisingWave offers columnar-based storage. Instead of using proprietary format, RisingWave stores analytical data based on Apache Iceberg. For more details, see [Iceberg table engine](/store/iceberg-table-engine).


### PR DESCRIPTION
1. Add a tab as the [landing page](https://risingwavelabs-iceberg-landing-page.mintlify.app/iceberg/overview) for Iceberg
2. Add a section [`Store data`](https://risingwavelabs-iceberg-landing-page.mintlify.app/store/overview), including overview and Iceberg table engine.

---Update: just removed the S3 table related content to control the scope of the change.
. Iceberg integration with S3 Tables (table engine, source, sink)
    Related: https://github.com/risingwavelabs/risingwave/pull/21018 
    Fix https://github.com/risingwavelabs/risingwave-docs/issues/333