### PR TITLE
Add note about hardware requirements for docker images

### DIFF
--- a/deploy/hardware-requirements.mdx
+++ b/deploy/hardware-requirements.mdx
@@ -11,6 +11,14 @@ RisingWave can run on the following hardware architectures:
 * ARM64
 * Mac with Apple Silicon
 
+
+<Note>
+The docker images for `x86_64` are built with AVX2 SIMD extensions, and the images for `aarch64` (ARM64) are built with NEON SIMD extensions. If your machine does not support these extensions, you must build the docker image with the build-arg `simd_disabled=true`.
+
+- To build the images, run the following from the project root: `docker build . -f docker/Dockerfile`.
+- To build the images without SIMD vector extensions, run the following from the project root `docker build . -f docker/Dockerfile --build-arg simd_disabled=true` and run any subsequent docker commands on the resultant image.
+</Note>
+
 ## Compute nodes
 
 Compute nodes handle query processing and state management. More resources enable higher query throughput. For cost efficiency, machines with high memory-to-CPU ratios (4:1 or higher) are recommended due to RisingWave's memory-intensive nature.

--- a/deploy/hardware-requirements.mdx
+++ b/deploy/hardware-requirements.mdx
@@ -11,8 +11,9 @@ RisingWave can run on the following hardware architectures:
 * ARM64
 * Mac with Apple Silicon
 
-
 <Note>
+**SIMD requirements for Docker images**
+
 The docker images for `x86_64` are built with AVX2 SIMD extensions, and the images for `aarch64` (ARM64) are built with NEON SIMD extensions. These must be supported by your machine. If not, build the docker image with the build-arg `simd_disabled=true`.
 
 - To build the images, run the following from the project root: `docker build . -f docker/Dockerfile`.

--- a/deploy/hardware-requirements.mdx
+++ b/deploy/hardware-requirements.mdx
@@ -13,7 +13,7 @@ RisingWave can run on the following hardware architectures:
 
 
 <Note>
-The docker images for `x86_64` are built with AVX2 SIMD extensions, and the images for `aarch64` (ARM64) are built with NEON SIMD extensions. If your machine does not support these extensions, you must build the docker image with the build-arg `simd_disabled=true`.
+The docker images for `x86_64` are built with AVX2 SIMD extensions, and the images for `aarch64` (ARM64) are built with NEON SIMD extensions. These must be supported by your machine. If not, build the docker image with the build-arg `simd_disabled=true`.
 
 - To build the images, run the following from the project root: `docker build . -f docker/Dockerfile`.
 - To build the images without SIMD vector extensions, run the following from the project root `docker build . -f docker/Dockerfile --build-arg simd_disabled=true` and run any subsequent docker commands on the resultant image.

--- a/get-started/quickstart.mdx
+++ b/get-started/quickstart.mdx
@@ -32,6 +32,8 @@ Ensure [Docker Desktop](https://docs.docker.com/get-docker/) is installed and ru
 docker run -it --pull=always -p 4566:4566 -p 5691:5691 risingwavelabs/risingwave:latest single_node
 ```
 
+Ensure your hardware supports the required SIMD extensions (AVX2 for x86_64, NEON for ARM64). See [SIMD requirements for Docker images](/deploy/hardware-requirements#supported-architectures) for details.
+
 ### Homebrew
 
 Ensure [Homebrew](https://brew.sh/) is installed, and run the following commands:


### PR DESCRIPTION
As discussed in Wechat group, put the note about [docker images](https://github.com/risingwavelabs/risingwave/blob/main/docker/README.md?plain=1#L85-L89) into doc site.

I insert it into the hardware requirements, let me know if there's a better place!