### PR TITLE
Fix: update create table command

### DIFF
--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -29,7 +29,8 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 [FORMAT data_format ENCODE data_encode [ (
     message='message',
     schema.location='location', ...) ]
-];
+]
+[ ENGINE = iceberg ];
 ```
 
 ## Notes
@@ -91,6 +92,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 | **INCLUDE** clause                | Extract fields not included in the payload as separate columns. For more details on its usage, see [INCLUDE clause](/ingestion/ingest-additional-fields-with-include-clause).                                                                                                                                                                                                                                                     |
 | **WITH** clause                   | Specify the connector settings here if trying to store all the source data. See the [Data ingestion](/ingestion/overview) page for the full list of supported source as well as links to specific connector pages detailing the syntax for each source.                                                                                                                                       |
 | **FORMAT** and **ENCODE** options | Specify the data format and the encoding format of the source data. To learn about the supported data formats, see [Data formats](/ingestion/supported-sources-and-formats#supported-formats).                                                                                                                                                                                                                  |
+| **ENGINE** | Specify the Iceberg table engine to store data natively in the Iceberg format. For more information, see [Create a table with the Iceberg engine](/store/iceberg-table-engine#3-create-a-table-with-the-iceberg-engine).                                                                                                                                                                                                                  |
 
 <Note>
 Please distinguish between the parameters set in the FORMAT and ENCODE options and those set in the WITH clause. Ensure that you place them correctly and avoid any misuse.

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -105,6 +105,11 @@ The append-only table does not support delete or update operations, nor does it 
 - Certain features are exclusively available for append-only tables, such as watermark and TTL (Time-To-Live).
 - Streaming jobs created downstream from append-only tables can leverage their append-only property to optimize performance. 
 
+
+## Use Iceberg table engine
+
+In a `CREATE TABLE` statement, you can specify `ENGINE = iceberg` to store table data in the Apache Iceberg format on external object storage. This provides an alternative to RisingWave’s default internal row-based storage, making it easier to persist data for long-term use and cross-system access. For more information on the syntax and usage, see [Iceberg table engine](/store/iceberg-table-engine).
+
 ## Watermarks
 
 RisingWave supports generating watermarks when creating an append-only streaming table. Watermarks are like markers or signals that track the progress of event time, allowing you to process events within their corresponding time windows. For more information on the syntax on how to create a watermark, see [Watermarks](/processing/watermarks).


### PR DESCRIPTION
Update create table command to include `engine=iceberg`

Reference: https://docs.risingwave.com/store/iceberg-table-engine#3-create-a-table-with-the-iceberg-engine