### PR TITLE
Document: add param for Iceberg sink

### DIFF
--- a/integrations/destinations/apache-iceberg.mdx
+++ b/integrations/destinations/apache-iceberg.mdx
@@ -44,6 +44,7 @@ WITH (
 | primary_key | The primary key for an upsert sink. It is only applicable to the upsert mode. |
 | partition_by | Optional. Specify partitioning using column names or transformations. Supported formats include: `column`, `transform(column)`, `transform(n,column)`, and `transform(n, column)`. Transformations can include functions like `bucket` or `truncate`, where `n` is an optional parameter. Ensure that the specified partition fields exist in the schema. |
 | commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 10. <br/>The behavior of this field also depends on the `sink_decouple` setting:<ul><li>If `sink_decouple` is true (the default), the default value of `commit_checkpoint_interval` is 10.</li> <li>If `sink_decouple` is set to false, the default value of `commit_checkpoint_interval` is 1.</li> <li>If `sink_decouple` is set to false and `commit_checkpoint_interval` is set to larger than 1, an error will occur.</li></ul> |
+| commit_retry_num | Optional. The number of times to retry a commit when an Iceberg commit fails. Default is 8. |
 | create_table_if_not_exists | Optional. When set to `true`, it will automatically create a table for the Iceberg sink. |
 | catalog.credential | Optional. Credential for accessing the Iceberg catalog, used to exchange for a token in the OAuth2 client credentials flow. Applicable only in the `rest` catalog. |
 | catalog.token | Optional. A bearer token for accessing the Iceberg catalog, used for interaction with the server. Applicable only in the `rest` catalog. |


### PR DESCRIPTION
## Description

add optional `commit_retry_num` for Iceberg sink

## Related code PR
https://github.com/risingwavelabs/risingwave/pull/20433

## Related doc issue
Fix https://github.com/risingwavelabs/risingwave-docs/issues/281