### PR TITLE
Document: update `create sink into` command

### DIFF
--- a/sql/commands/sql-create-sink-into.mdx
+++ b/sql/commands/sql-create-sink-into.mdx
@@ -8,14 +8,16 @@ description: "Use the `CREATE SINK INTO` command to create a sink into RisingWav
 ```sql
 CREATE SINK [ IF NOT EXISTS ] sink_name INTO table_name [ ( col_name [ , ... ] ) ]
 [FROM sink_from | AS select_query]
+[ WITH ( sink_option = value [, ...] ) ];
 ```
 
 ## Parameters
 
 | Parameter or clause | Description                                                                                                                                                                                      |
 | :------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| sink\_name          | The name of the sink. If a schema name is given (for example, CREATE SINK\<schema>.\<sink> ...), then the sink is created in the specified schema. Otherwise it is created in the current schema. |
+| sink\_name          | The name of the sink. If a schema name is given (for example, `CREATE SINK <schema>.<sink> ...`), then the sink is created in the specified schema. Otherwise it is created in the current schema. |
 | col\_name           | The corresponding table columns in the sink result. For those columns not listed, it will be inserted as the default value defined in the table.                                                 |
+| `WITH` clause           | You can use options such as `type = 'append-only'` and `force_append_only = 'true'` to explicitly control the append-only behavior.                                                 |
 
 <Note>
 A table without a primary key can only accept the append-only sink.


### PR DESCRIPTION
## Description
`create sink into` supports options of `append-only` and `force_append_only`

## Related doc issue
Fix https://github.com/risingwavelabs/risingwave-docs/issues/318