### PR TITLE
Add v2.4 release note

### DIFF
--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -5,39 +5,41 @@ description: This page summarizes changes in each version of RisingWave, includi
 
 <Update label="v2.4.0" description="2025-05-22">
 
+Support for certain earlier version will end following the release of v2.4, please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
+
 ## SQL features
 
 - SQL commands:
-    - Supports `EXPLAIN ANALYZE` command to analyze the actual runtime performance of a streaming job. https://github.com/risingwavelabs/risingwave/pull/20715, https://github.com/risingwavelabs/risingwave/pull/20966
-    - Supports configurable `streaming_parallelism` settings for tables, indexes, materialized views, sinks, and sources. https://github.com/risingwavelabs/risingwave/pull/21366
-    - Supports `DESCRIBE FRAGMENTS` command to check the execution fragments of an existing job. https://github.com/risingwavelabs/risingwave/pull/21354
-    - Supports **NOT NULL** constraints in table schemas for both batch and streaming operations. https://github.com/risingwavelabs/risingwave/pull/20822
-    - Supports `GRANT` and `REVOKE` privileges on connection, function and secret. ****https://github.com/risingwavelabs/risingwave/pull/20755
-    - `ALTER SYSTEM` now applies session variable changes immediately to the current session. https://github.com/risingwavelabs/risingwave/pull/21294
+    - Supports `EXPLAIN ANALYZE` command to analyze the actual runtime performance of a streaming job. [#20715](https://github.com/risingwavelabs/risingwave/pull/20715), [#20966](https://github.com/risingwavelabs/risingwave/pull/20966)
+    - Supports configurable `streaming_parallelism` settings for tables, indexes, materialized views, sinks, and sources. [#21366](https://github.com/risingwavelabs/risingwave/pull/21366)
+    - Supports `DESCRIBE FRAGMENTS` command to check the execution fragments of an existing job. [#21354](https://github.com/risingwavelabs/risingwave/pull/21354)
+    - Supports **NOT NULL** constraints in table schemas for both batch and streaming operations. [#20822](https://github.com/risingwavelabs/risingwave/pull/20822)
+    - Supports `GRANT` and `REVOKE` privileges on connection, function and secret. [#20755](https://github.com/risingwavelabs/risingwave/pull/20755)
+    - `ALTER SYSTEM` now applies session variable changes immediately to the current session. [#21294](https://github.com/risingwavelabs/risingwave/pull/21294)
     
 - System catalog:
-    - Adds system catalogs `iceberg_tables` and `iceberg_namespace_properties` . https://github.com/risingwavelabs/risingwave/pull/21400
-    - Adds system function `has_function_privilege`. https://github.com/risingwavelabs/risingwave/pull/20755
+    - Adds system catalogs `iceberg_tables` and `iceberg_namespace_properties`. [#21400](https://github.com/risingwavelabs/risingwave/pull/21400)
+    - Adds system function `has_function_privilege`. [#20755](https://github.com/risingwavelabs/risingwave/pull/20755)
 
 ## Connectors
 
-- **Deprecation notice:** Deprecates the Pulsar Iceberg reader and removed the `icelake` dependency. https://github.com/risingwavelabs/risingwave/pull/20844
-- **Deprecation notice:** The legacy S3 source is now fully deprecated in v2.4.0. https://github.com/risingwavelabs/risingwave/pull/20658
-- Supports creating an append-only table with the Iceberg engine. https://github.com/risingwavelabs/risingwave/pull/21811
-- Adds `commit_retry_num` option to configure the number of commit retries on Iceberg failures. https://github.com/risingwavelabs/risingwave/pull/20433
-- Supports Redis Pub/Sub messaging in sink connectors. https://github.com/risingwavelabs/risingwave/pull/20991
-- Supports Iceberg sink and Iceberg source on Azure Blob. https://github.com/risingwavelabs/risingwave/pull/21468
-- Supports exactly once consistency semantics for Iceberg sink. https://github.com/risingwavelabs/risingwave/pull/19771
+- **Deprecation notice:** Deprecates the Pulsar Iceberg reader and removed the `icelake` dependency. [#20844](https://github.com/risingwavelabs/risingwave/pull/20844)
+- **Deprecation notice:** The legacy S3 source is now fully deprecated in v2.4.0. [#20658](https://github.com/risingwavelabs/risingwave/pull/20658)
+- Supports creating an append-only table with the Iceberg engine. [#21811](https://github.com/risingwavelabs/risingwave/pull/21811)
+- Adds `commit_retry_num` option to configure the number of commit retries on Iceberg failures. [#20433](https://github.com/risingwavelabs/risingwave/pull/20433)
+- Supports Redis Pub/Sub messaging in sink connectors. [#20991](https://github.com/risingwavelabs/risingwave/pull/20991)
+- Supports Iceberg sink and Iceberg source on Azure Blob. [#21468](https://github.com/risingwavelabs/risingwave/pull/21468)
+- Supports exactly once consistency semantics for Iceberg sink. [#19771](https://github.com/risingwavelabs/risingwave/pull/19771)
 
 ## Cluster configuration changes
 
-- Adds system parameter `per_database_isolation`  to enable per-database failure isolation. https://github.com/risingwavelabs/risingwave/pull/20872
-- Adds session variable `streaming_enable_materialized_expressions` to enable materialized expressions. https://github.com/risingwavelabs/risingwave/pull/21552
-- Adds session variable `streaming_force_filter_inside_join` to force filter to be pushed down into inner join. https://github.com/risingwavelabs/risingwave/pull/21289
+- Adds system parameter `per_database_isolation`  to enable per-database failure isolation. [#20872](https://github.com/risingwavelabs/risingwave/pull/20872)
+- Adds session variable `streaming_enable_materialized_expressions` to enable materialized expressions. [#21552](https://github.com/risingwavelabs/risingwave/pull/21552)
+- Adds session variable `streaming_force_filter_inside_join` to force filter to be pushed down into inner join. [#21289](https://github.com/risingwavelabs/risingwave/pull/21289)
 
 ## Fixes
 
-- Security for logical views has been improved to correctly prevent unauthorized access. https://github.com/risingwavelabs/risingwave/pull/20941
+- Security for logical views has been improved to correctly prevent unauthorized access. [#20941](https://github.com/risingwavelabs/risingwave/pull/20941)
 
 ## Assets
 
@@ -53,7 +55,7 @@ See the **Full Changelog** [here](https://github.com/risingwavelabs/risingwave/c
 </Update>
 
 <Update label="v2.3.0" description="2025-04-14">
-Support for RisingWave v2.1 will end upon the release of v2.3. If you're using v2.1, please plan your upgrade to a newer version (v2.2 or later) soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
+Support for certain earlier version will end following the release of v2.3, please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
 
 ## SQL features
 

--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -3,6 +3,55 @@ title: Release notes
 description: This page summarizes changes in each version of RisingWave, including new features and important bug fixes.
 ---
 
+<Update label="v2.4.0" description="2025-05-22">
+
+## SQL features
+
+- SQL commands:
+    - Supports `EXPLAIN ANALYZE` command to analyze the actual runtime performance of a streaming job. https://github.com/risingwavelabs/risingwave/pull/20715, https://github.com/risingwavelabs/risingwave/pull/20966
+    - Supports configurable `streaming_parallelism` settings for tables, indexes, materialized views, sinks, and sources. https://github.com/risingwavelabs/risingwave/pull/21366
+    - Supports `DESCRIBE FRAGMENTS` command to check the execution fragments of an existing job. https://github.com/risingwavelabs/risingwave/pull/21354
+    - Supports **NOT NULL** constraints in table schemas for both batch and streaming operations. https://github.com/risingwavelabs/risingwave/pull/20822
+    - Supports `GRANT` and `REVOKE` privileges on connection, function and secret. ****https://github.com/risingwavelabs/risingwave/pull/20755
+    - `ALTER SYSTEM` now applies session variable changes immediately to the current session. https://github.com/risingwavelabs/risingwave/pull/21294
+    
+- System catalog:
+    - Adds system catalogs `iceberg_tables` and `iceberg_namespace_properties` . https://github.com/risingwavelabs/risingwave/pull/21400
+    - Adds system function `has_function_privilege`. https://github.com/risingwavelabs/risingwave/pull/20755
+
+## Connectors
+
+- **Deprecation notice:** Deprecates the Pulsar Iceberg reader and removed the `icelake` dependency. https://github.com/risingwavelabs/risingwave/pull/20844
+- **Deprecation notice:** The legacy S3 source is now fully deprecated in v2.4.0. https://github.com/risingwavelabs/risingwave/pull/20658
+- Supports creating an append-only table with the Iceberg engine. https://github.com/risingwavelabs/risingwave/pull/21811
+- Adds `commit_retry_num` option to configure the number of commit retries on Iceberg failures. https://github.com/risingwavelabs/risingwave/pull/20433
+- Supports Redis Pub/Sub messaging in sink connectors. https://github.com/risingwavelabs/risingwave/pull/20991
+- Supports Iceberg sink and Iceberg source on Azure Blob. https://github.com/risingwavelabs/risingwave/pull/21468
+- Supports exactly once consistency semantics for Iceberg sink. https://github.com/risingwavelabs/risingwave/pull/19771
+
+## Cluster configuration changes
+
+- Adds system parameter `per_database_isolation`  to enable per-database failure isolation. https://github.com/risingwavelabs/risingwave/pull/20872
+- Adds session variable `streaming_enable_materialized_expressions` to enable materialized expressions. https://github.com/risingwavelabs/risingwave/pull/21552
+- Adds session variable `streaming_force_filter_inside_join` to force filter to be pushed down into inner join. https://github.com/risingwavelabs/risingwave/pull/21289
+
+## Fixes
+
+- Security for logical views has been improved to correctly prevent unauthorized access. https://github.com/risingwavelabs/risingwave/pull/20941
+
+## Assets
+
+- Run this version from Docker:
+`docker run -it --pull=always -p 4566:4566 -p 5691:5691 risingwavelabs/risingwave:v2.4.0 standalone`
+- [Prebuilt all-in-one library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v2.4.0/risingwave-v2.4.0-x86_64-unknown-linux-all-in-one.tar.gz)
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v2.4.0.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v2.4.0.tar.gz)
+- [risectl - a CLI tool for managing and accessing RisingWave clusters](https://github.com/risingwavelabs/risingwave/releases/download/v2.4.0/risectl-v2.4.0-x86_64-unknown-linux.tar.gz)
+
+See the **Full Changelog** [here](https://github.com/risingwavelabs/risingwave/compare/release-2.3...release-2.4).
+
+</Update>
+
 <Update label="v2.3.0" description="2025-04-14">
 Support for RisingWave v2.1 will end upon the release of v2.3. If you're using v2.1, please plan your upgrade to a newer version (v2.2 or later) soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
 
@@ -66,6 +115,8 @@ Support for RisingWave v2.1 will end upon the release of v2.3. If you're using 
 - [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v2.3.0.zip)
 - [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v2.3.0.tar.gz)
 - [risectl - a CLI tool for managing and accessing RisingWave clusters](https://github.com/risingwavelabs/risingwave/releases/download/v2.3.0/risectl-v2.3.0-x86_64-unknown-linux.tar.gz)
+
+See the **Full Changelog** [here](https://github.com/risingwavelabs/risingwave/compare/release-2.2...release-2.3).
 
 
 </Update>

--- a/changelog/release-support-policy.mdx
+++ b/changelog/release-support-policy.mdx
@@ -17,7 +17,7 @@ The following table summarizes support end dates for recent RisingWave releases.
 | `v1.10` | Jul 30, 2024 | Jan 26, 2025                                           |
 | `v2.0`  | Sep 26, 2024 | Feb 11, 2025 *(Policy verification recommended)*       |
 | `v2.1`  | Dec 7, 2024  | May 7, 2025                                |
-| `v2.2`  | Feb 11, 2025 | Apr 26, 2025 or upon the release of `v2.4`, whichever is later |
+| `v2.2`  | Feb 11, 2025 | May 22, 2025 |
 | `v2.3`  | May 7, 2025  | July 22, 2025 or upon the release of `v2.5`, whichever is later|
 
 ## Policy details

--- a/mint.json
+++ b/mint.json
@@ -84,7 +84,7 @@
     }
   },
   "versions": [
-   "Current (v2.3)",
+   "Current (v2.4)",
    {
     "name": "Archived",
     "url": "https://legacy-docs.risingwave-labs.com/"


### PR DESCRIPTION
As v2.4 is released, add the release note as well.

For version policy, based on this [context](https://risingwave-labs.slack.com/archives/C03KED89H88/p1747895585758479):

> Support end date for 2.1 should be 2.3.0, but with the issues in 2.3.0 and 2.3.1, we recommend users to use 2.3.2, which was released on May 7. 

 Therefore, saying that "support for 2.1 ends with the release of 2.3", or "support for 2.2 ends with 2.4" directly might not be accurate. So revised the wording to be a bit vague.

Let me know if any comments.