### PR TITLE
Chore: Remove public preview and technical preview labels

### DIFF
--- a/changelog/product-lifecycle.mdx
+++ b/changelog/product-lifecycle.mdx
@@ -1,7 +1,7 @@
 ---
 title: RisingWave feature lifecycle and deprecation
 sidebarTitle: Feature lifecycle and deprecation
-description: "This document outlines the stages of development for individual features within RisingWave (Technical Preview, Public Preview, General Availability), and the policy for how features are deprecated and removed from the product. It also provides a list of features currently in Public Preview."
+description: "This document outlines the stages of development for individual features within RisingWave, and the policy for how features are deprecated and removed from the product."
 ---
 
 In RisingWave, the release of product features typically follows three main stages: **Technical preview**, **Public preview**, and **General availability (GA)**. Each stage reflects the feature's maturity and readiness for production use.
@@ -16,7 +16,7 @@ In RisingWave, the release of product typically follows three main stages:
 
 - **Technical preview**: The technical preview stage is where we release a new feature for testing and feedback. It’s not fully polished or finalized and is subject to change. We cannot guarantee its continued support in future releases, and it may be discontinued without notice. You may use this feature at your own risk.
 
-- **Public preview**: The public preview stage is where we’ve incorporated feedback from the technical preview and are nearing the final product. It’s more stable than the technical preview, but there may still be some bugs and issues. During this stage, the corresponding guides are available in the official documentation for your reference. For the overview of all such features, see the list below.
+- **Public preview**: The public preview stage is where we’ve incorporated feedback from the technical preview and are nearing the final product. It’s more stable than the technical preview, but there may still be some bugs and issues. During this stage, the corresponding guides are available in the official documentation for your reference.
 
 - **General availability (GA)**: All other features are considered to be generally available. The general availability stage is where the feature is fully developed, tested, and ready for use in production environments. While GA features are stable and supported, they may eventually be deprecated as part of the product lifecycle. For details on how we manage feature deprecations, see the [Feature deprecation policy](#feature-deprecation-policy).
 
@@ -57,34 +57,3 @@ In such cases, we notify users as soon as possible and provide guidance to minim
 We encourage users to share feedback during the deprecation phase. This helps us address concerns, improve migration experiences, and better serve our users.
 
 For more information about how we manage feature deprecations, please contact us via our [Slack channel](https://go.risingwave.com/slack).
-
-## Features in the public preview stage
-
-As introduced above, when you see a "Public preview" note in the documentation, it indicates that a feature has not yet achieved 100% stability. We recommend evaluating the feature according to your specific use case. If you encounter any issues with the feature, please contact us via our [Slack channel](https://www.risingwave.com/slack). We also welcome any of your feedback to help us improve it.
-
-Below is a list of all features in the public preview phase:
-
-| Feature name |  Start version |
-| :-- | :-- |
-| [Database isolation](/operate/workload-isolation-interaction#database-isolation) | 2.3 |
-| [Resource groups](/operate/workload-isolation-interaction#resource-groups) | 2.3 |
-| [Cross-database queries](/operate/workload-isolation-interaction#cross-database-queries) | 2.3 |
-| [Ingest data from PostgreSQL 17 using CDC](/ingestion/sources/pg-cdc) | 2.3 |
-| [Sink connector `postgres`](/integrations/destinations/postgresql#create-a-sink)| 2.2 |
-| [Ingest data from MySQL table](/integrations/sources/mysql-table)| 2.2 |
-| [EXPLAIN option of FORMAT](/sql/commands/sql-explain#explain-options)| 2.2 |
-| [Ingest data from Postgres table](/integrations/sources/postgresql-table) | 2.1 |
-| [Ingest data from webhook](/integrations/sources/webhook) | 2.1 |
-| [Shared source](/sql/commands/sql-create-source#shared-source)  | 2.1  |
-| [ASOF join](/processing/sql/joins#asof-joins) | 2.1 |
-| [Partitioned Postgres CDC table](/integrations/sources/postgresql-cdc#ingest-data-from-a-partitioned-table) | 2.1 |
-| [Map type](/sql/data-types/map-type) | 2.0 |
-| [Azure Blob sink](/integrations/destinations/azure-blob) | 2.0 |
-| [Approx percentile](/sql/functions/aggregate#approx-percentile) | 2.0 |
-| [Auto schema change in MySQL CDC](/integrations/sources/mysql-cdc#automatically-change-schema) | 2.0 |
-| [SQL Server CDC source](/integrations/sources/sql-server-cdc) | 2.0 |
-| [Sink data in Parquet format](/delivery/overview#sink-data-in-parquet-or-json-format) | 2.0 |
-| [Time travel queries](/processing/time-travel-queries) | 2.0 |
-| [Manage secrets](/operate/manage-secrets) | 2.0 |
-
-This table will be updated regularly to reflect the latest status of features as they progress through the release stages.

--- a/deploy/node-specific-configurations.mdx
+++ b/deploy/node-specific-configurations.mdx
@@ -95,8 +95,6 @@ Storage configurations can be set in `[storage]` and `[storage.xxx]` sections.
 
 In RisingWave, several node-specific configurations are provided to control the refilling process of file cache and block cache.
 
-For now, the file cache and cache refilling features are still in technical preview. The configuration items might change in future versions.
-
 <Accordion title="What is the file cache and block cache refilling?">
 The file cache serves as an extension of the memory block cache for the LSM-tree, which is used to speed up storage IO-intensive workloads.
 

--- a/ingestion/sources/pg-cdc.mdx
+++ b/ingestion/sources/pg-cdc.mdx
@@ -6,12 +6,6 @@ description: "Ingest real-time changes from your PostgreSQL database using chang
 
 This guide explains how to connect RisingWave to a PostgreSQL database to ingest data changes in real time using change data capture (CDC). RisingWave supports PostgreSQL versions 10, 11, 12, 13, 14, 15, 16, and 17.
 
-<Note>
-**PUBLIC PREVIEW**
-
-Support for PostgreSQL 17 is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
 ## Prerequisites
 
 *   A running PostgreSQL database (self-hosted or AWS RDS/Aurora).

--- a/integrations/destinations/postgresql.mdx
+++ b/integrations/destinations/postgresql.mdx
@@ -106,13 +106,6 @@ WITH (
 | type                | Sink data type. Supported types: <ul><li>`append-only`: Sink data as INSERT operations.</li><li>`upsert`: Sink data as UPDATE, INSERT and DELETE operations.</li></ul>                                                                        |
 | primary\_key        | Required if type is upsert. The primary key of the sink, which should match the primary key of the downstream table.                                                                                             |
 
-
-<Note>
-**PUBLIC PREVIEW**
-
-Sink connector `postgres` is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
 <Note>
 Sink connector `postgres` is added in version 2.2.
 </Note>

--- a/integrations/sources/mysql-cdc.mdx
+++ b/integrations/sources/mysql-cdc.mdx
@@ -401,12 +401,7 @@ This is a Premium Edition feature. All Premium Edition features are available ou
 
 For a full list of Premium Edition features, see [RisingWave Premium Edition](/get-started/rw-premium-edition-intro). 
 </Tip>
-<Note>
-**PUBLIC PREVIEW**
 
-This feature is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-
-</Note>
 RisingWave supports auto schema changes in MySQL CDC. It ensures that your RisingWave pipeline stays synchronized with any schema changes in the source database, reducing the need for manual updates and preventing inconsistencies.
 
 Currently, RisingWave supports the `ALTER TABLE` command with the following operations, and we plan to add support for additional DDL operations in future releases.

--- a/integrations/sources/mysql-table.mdx
+++ b/integrations/sources/mysql-table.mdx
@@ -9,12 +9,6 @@ RisingWave allows you to query MySQL tables directly with the `mysql_query` tabl
 Unlike CDC, which continuously syncs data changes, this function lets you fetch data directly from MySQL when needed. Therefore, this approach is ideal for static or infrequently updated data, as it's more resource-efficient than maintaining a constant CDC connection.
 
 <Note>
-**PUBLIC PREVIEW**
-
-This feature is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
-<Note>
 Added in version 2.2.
 </Note>
 

--- a/integrations/sources/postgresql-table.mdx
+++ b/integrations/sources/postgresql-table.mdx
@@ -9,12 +9,6 @@ RisingWave allows you to query PostgreSQL tables directly with the `postgres_que
 Unlike CDC, which continuously syncs data changes, this function lets you fetch data directly from PostgreSQL when needed. Therefore, this approach is ideal for static or infrequently updated data, as it's more resource-efficient than maintaining a constant CDC connection.
 
 <Note>
-**PUBLIC PREVIEW**
-
-This feature is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
-<Note>
 Added in version 2.1.
 </Note>
 

--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -11,12 +11,6 @@ RisingWave can serve as a webhook destination, directly accepting HTTP requests 
 
 This direct integration eliminates the need for an intermediary message broker like Kafka. Instead of setting up and maintaining an extra Kafka cluster, you can directly send data to RisingWave to process it in real-time, which enables efficient data ingestion and stream processing without extra infrastructure.
 
-<Note>
-**PUBLIC PREVIEW**
-
-This feature is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
 ## Creating a webhook table in RisingWave
 
 To utilize webhook sources in RisingWave, you need to create a table configured to accept webhook requests. Below is a basic example of how to set up such a table:

--- a/operate/workload-isolation-interaction.mdx
+++ b/operate/workload-isolation-interaction.mdx
@@ -18,11 +18,6 @@ PREMIUM EDITION FEATURE
 For a full list of Premium Edition features, see [RisingWave Premium Edition](/get-started/rw-premium-edition-intro).
 </Tip>
 
-<Note>
-PUBLIC PREVIEW
-
-**Database isolation**, **resource groups**, and **cross-database queries** are currently in public preview. While nearing the final product, it may still evolve. Please refer to our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage) for the latest status or reach out via our [Slack channel](https://www.risingwave.com/slack) with feedback or issues.
-</Note>
 
 This topic explains these capabilities and how they work together.
 

--- a/sql/commands/sql-create-database.mdx
+++ b/sql/commands/sql-create-database.mdx
@@ -29,13 +29,6 @@ Resource groups is a Premium Edition feature. All Premium Edition features are a
 For a full list of Premium Edition features, see [RisingWave Premium Edition](/get-started/rw-premium-edition-intro). 
 </Tip>
 
-<Note>
-**PUBLIC PREVIEW**
-
-Resource groups is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
-
 ## Example
 
 ```sql

--- a/sql/commands/sql-create-source.mdx
+++ b/sql/commands/sql-create-source.mdx
@@ -93,12 +93,6 @@ For complete step-to-step guides about ingesting MySQL and PostgreSQL data using
 Shared source improves resource utilization and data consistency when working with Kafka sources in RisingWave. This will only affect Kafka sources created after the version updated and will not affect any existing Kafka sources.
 
 <Note>
-**PUBLIC PREVIEW**
-
-This feature is currently in public preview, meaning it is nearing the final product but may not yet be fully stable. If you encounter any issues or have feedback, please reach out to us via our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve this feature. For more details, see our [Public Preview Feature List](/changelog/product-lifecycle#features-in-the-public-preview-stage).
-</Note>
-
-<Note>
 Shared Kafka source is available since version 2.1. Other sources are unaffected. We plan to gradually upgrade other sources to the be shared as well in the future.
 
 `ALTER SOURCE [ADD COLUMN | REFRESH SCHEMA]` for shared source is available since version 2.2.


### PR DESCRIPTION
## Description

Remove labels of public preview and technical preview.


## Checklist

- [x] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
