### PR TITLE
improve optional step in webhook docs

### DIFF
--- a/integrations/sources/eventbridge-webhook.mdx
+++ b/integrations/sources/eventbridge-webhook.mdx
@@ -9,20 +9,7 @@ Amazon EventBridge is a serverless event bus service that enables you to easily 
 
 This guide will walk through the steps to set up RisingWave as a destination for Amazon EventBridge webhooks.
 
-## 1. Optional: Create a secret in RisingWave
-
-First, create a secret in RisingWave to securely store a secret string. This secret will be used to validate incoming webhook requests from Amazon EventBridge. This is the recommended way to verify the signature. You could also use a raw string to verify.
-
-```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'TEST_WEBHOOK';
-```
-
-| Parameter or clause | Description |
-| :--------- | :-----------|
-|`test_secret`| The name of the secret.|
-| `TEST_WEBHOOK`| The secret string used for signing and verifying webhook payloads. Replace this with a secure, random string.|
-
-## 2. Create a table in RisingWave
+## 1. Create a table in RisingWave
 
 Next, create a table configured to accept webhook data from Amazon EventBridge.
 
@@ -40,6 +27,7 @@ create table wbhtable (
 | Parameter or clause | Description |
 | :--------- | :-----------|
 | `data JSONB` | Defines the name of column to store the JSON payload from the webhook. Currently, only `JSONB` type is supported for webhook tables. |
+| `SECRET <secret>` | Use an existing [secret](/operate/manage-secrets) to verify incoming webhookd requests. This is optional. You can also use a raw string to verify.|
 | `headers->>'...'` | Extracts the signature provided by Amazon EventBridge in the `authorization` HTTP header. The header key can be any string value and you can specify it when you create your webhook destination for RisingWave. <br/> <br/> In `secure_compare()` function, the whole HTTP header is interpreted as a JSONB object, and you can access the header value using the `->>` operator, but only the lower-case header names in the `->>` operator, otherwise the verification will fail. |
 | `test_secret` | Provides the expected signature. In the example above, we directly compare the secret value of `test_secret` with the signature provided in the headers to verify the requests. |
 | `secure_compare(...)` | Validates requests by matching the header signature against the computed signature, ensuring only authenticated requests are processed. The `secure_compare()` function compares two strings in a fixed amount of time, regardless of whether they are equal or not, ensuring that the comparison is secure and resistant to timing attacks. |
@@ -58,7 +46,7 @@ CREATE TABLE wbhtable (
 );
 ```
 
-## 3. Set up webhook in Amazon EventBridge
+## 2. Set up webhook in Amazon EventBridge
 
 After configuring RisingWave to accept webhook data, set up Amazon EventBridge to send events to your RisingWave instance.
 
@@ -120,11 +108,11 @@ Finish Other Configurations and Save Your Configuration:
 </Step>
 </Steps>
 
-## 4. Push Data from Amazon EventBridge via Webhook
+## 3. Push Data from Amazon EventBridge via Webhook
 
 With the webhook configured, Amazon EventBridge will automatically send HTTP POST requests to your RisingWave webhook URL whenever there are data generated from your AWS platform. RisingWave will receive these requests, validate the signatures, and insert the payload data into the target table.
 
-## 5. Further event processing
+## 4. Further event processing
 
 The data in the table is already ready for further processing. You can access the fields using `data->'field_name'` in SQL queries.
 

--- a/integrations/sources/github-webhook.mdx
+++ b/integrations/sources/github-webhook.mdx
@@ -8,20 +8,7 @@ GitHub webhook allows you to build or set up integrations that subscribe to cert
 
 This guide will walk through the steps to set up RisingWave as a destination for GitHub webhooks.
 
-## 1. Optional: Create a secret in RisingWave
-
-First, create a secret in RisingWave to securely store a secret string. This secret will be used to validate incoming webhook requests from GitHub. This is the recommended way to verify the signature. You could also use a raw string to verify.
-
-```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'TEST_WEBHOOK';
-```
-
-| Parameter or clause | Description |
-| :--------- | :-----------|
-|`test_secret`| The name of the secret.|
-| `TEST_WEBHOOK`| The secret string used for signing and verifying webhook payloads. Replace this with a secure, random string.|
-
-## 2. Create a table in RisingWave
+## 1. Create a table in RisingWave
 
 Next, create a table configured to accept webhook data from GitHub.
 
@@ -40,6 +27,7 @@ CREATE TABLE wbhtable (
 | Parameter or clause | Description |
 | :--------- | :-----------|
 | `data JSONB` | Defines the name of column to store the JSON payload from the webhook. Currently, only `JSONB` type is supported for webhook tables. |
+| `SECRET <secret>` | Use an existing [secret](/operate/manage-secrets) to verify incoming webhookd requests. This is optional. You can also use a raw string to verify.|
 | `headers->>'...'` | Extracts the signature provided by GitHub in the `x-hub-signature-256` HTTP header. <br/> <br/> In `secure_compare()` function, the whole HTTP header is interpreted as a JSONB object, and you can access the header value using the `->>` operator, but only the lower-case header names in the `->>` operator, otherwise the verification will fail. |
 |`'sha256=' \|\| encode(...)` | Computes the expected signature. In the example above, it generates an `HMAC SHA-256` hash of the payload (`data`) using the secret (`test_secret`), encodes it in hexadecimal, and prefixes it with `sha256=`.|
 | `secure_compare(...)` | Validates requests by matching the header signature against the computed signature, ensuring only authenticated requests are processed. The `secure_compare()` function compares two strings in a fixed amount of time, regardless of whether they are equal or not, ensuring that the comparison is secure and resistant to timing attacks. |
@@ -60,7 +48,7 @@ CREATE TABLE wbhtable (
 );
 ```
 
-## 3. Set up webhook in GitHub
+## 2. Set up webhook in GitHub
 
 After configuring RisingWave to accept webhook data, set up GitHub to send events to your RisingWave instance.
 
@@ -101,11 +89,11 @@ Configure the webhook settings:
 Click **Add webhook** at the bottom of the page to save.
 </Step>
 </Steps>
-## 4. Push data from GitHub via webhook
+## 3. Push data from GitHub via webhook
 
 With the webhook configured, GitHub will automatically send HTTP POST requests to your RisingWave webhook URL whenever the specified events occur (e.g., pushes to the repository). RisingWave will receive these requests, validate the signatures, and insert the payload data into the target table.
 
-## 5. Further event processing
+## 4. Further event processing
 The data in the table is already ready for further processing. You can access the fields using `data->'field_name'` in SQL queries.
 
 You can create a materialized view to extract specific fields from the JSON payload.

--- a/integrations/sources/hubspot-webhook.mdx
+++ b/integrations/sources/hubspot-webhook.mdx
@@ -10,20 +10,7 @@ HubSpot webhooks are not available on all HubSpot plans. You must have the appro
 
 This guide will walk through the steps to set up RisingWave as a destination for HubSpot webhooks.
 
-## 1. Optional: Create a secret in RisingWave
-
-First, create a secret in RisingWave to securely store a secret string. This secret will be used to validate incoming webhook requests from HubSpot. This is the recommended way to verify the signature. You could also use a raw string to verify.
-
-```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'TEST_WEBHOOK';
-```
-
-| Parameter or clause | Description |
-| :--------- | :-----------|
-|`test_secret`| The name of the secret.|
-| `TEST_WEBHOOK`| The secret string used for signing and verifying webhook payloads. Replace this with a secure, random string. If you are using signature V2, please fill the client secret of your HubSpot APP, the format of which should be `yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy` |
-
-## 2. Create a table in RisingWave
+## 1. Create a table in RisingWave
 
 Next, create a table configured to accept webhook data from HubSpot.
 
@@ -49,6 +36,7 @@ CREATE TABLE wbhtable (
 | Parameter or clause | Description |
 | :--------- | :-----------|
 | `data JSONB` | Defines the name of column to store the JSON payload from the webhook. Currently, only `JSONB` type is supported for webhook tables. |
+| `SECRET <secret>` | Use an existing [secret](/operate/manage-secrets) to verify incoming webhookd requests. This is optional. You can also use a raw string to verify.|
 | `headers->>'...'` | Extracts the signature provided by HubSpot in the `x-hubspot-signature` HTTP header. <br/> <br/> In `secure_compare()` function, the whole HTTP header is interpreted as a JSONB object, and you can access the header value using the `->>` operator, but only the lower-case header names in the `->>` operator, otherwise the verification will fail. |
 | `encode(...)` | Computes the expected signature by concatenating the secret, HTTP method (`POST`), RisingWave Webhook URL (`http://127.0.0.1:4560/webhook/dev/public/` in this example), and the request body converted from UTF-8 `data`. It then takes a `SHA-256` hash of this string and encodes it in hex. |
 | `secure_compare(...)` | Validates requests by matching the header signature against the computed signature, ensuring only authenticated requests are processed. The `secure_compare()` function compares two strings in a fixed amount of time, regardless of whether they are equal or not, ensuring that the comparison is secure and resistant to timing attacks. |
@@ -78,7 +66,7 @@ CREATE TABLE wbhtable (
 );
 ```
 
-## 3. Set up webhook in HubSpot
+## 2. Set up webhook in HubSpot
 
 After configuring RisingWave to accept webhook data, set up HubSpot to send events to your RisingWave instance.
 
@@ -107,11 +95,11 @@ While the official [HubSpot webhook documentation](https://knowledge.hubspot.com
 
 - **Testing Your Configuration**: Use the **test actions** feature in HubSpot to verify that your webhook and RisingWave setup work as intended. This helps confirm that the configuration is correct before putting it into production.
 
-## 4. Push data from HubSpot via webhook
+## 3. Push data from HubSpot via webhook
 
 With the webhook configured, HubSpot will automatically send HTTP POST requests to your RisingWave webhook URL whenever the specified condition is satisfied. RisingWave will receive these requests, validate the signatures, and insert the payload data into the target table.
 
-## 5. Further event processing
+## 4. Further event processing
 
 The data in the table is already ready for further processing. You can access the fields using `data->'field_name'` in SQL queries.
 

--- a/integrations/sources/rudderstack-webhook.mdx
+++ b/integrations/sources/rudderstack-webhook.mdx
@@ -8,20 +8,7 @@ RudderStack is a Customer Data Platform (CDP) that enables you to collect, route
 
 This guide will walk through the steps to set up RisingWave as a destination for RudderStack webhooks.
 
-## 1. Optional: Create a secret in RisingWave
-
-First, create a secret in RisingWave to securely store a secret string. This secret will be used to validate incoming webhook requests from RudderStack. This is the recommended way to verify the signature. You could also use a raw string to verify.
-
-```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'TEST_WEBHOOK';
-```
-
-| Parameter or clause | Description |
-| :--------- | :-----------|
-|`test_secret`| The name of the secret.|
-| `TEST_WEBHOOK`| The secret string used for signing and verifying webhook payloads. Replace this with a secure, random string.|
-
-## 2. Create a table in RisingWave
+## 1. Create a table in RisingWave
 
 Next, create a table configured to accept webhook data from RudderStack.
 
@@ -39,6 +26,7 @@ create table wbhtable (
 | Parameter or clause | Description |
 | :--------- | :-----------|
 | `data JSONB` | Defines the name of column to store the JSON payload from the webhook. Currently, only `JSONB` type is supported for webhook tables. |
+| `SECRET <secret>` | Use an existing [secret](/operate/manage-secrets) to verify incoming webhookd requests. This is optional. You can also use a raw string to verify.|
 | `headers->>'...'` | Extracts the signature provided by RudderStack in the `authorization` HTTP header. The header key can be any string value and you can specify it when you create your webhook destination for RisingWave. <br/> <br/> In `secure_compare()` function, the whole HTTP header is interpreted as a JSONB object, and you can access the header value using the `->>` operator, but only the lower-case header names in the `->>` operator, otherwise the verification will fail. |
 | `test_secret` | Provides the expected signature. In the example above, we directly compare the secret value of `test_secret` with the signature provided in the headers to verify the requests. |
 | `secure_compare(...)` | Validates requests by matching the header signature against the computed signature, ensuring only authenticated requests are processed. The `secure_compare()` function compares two strings in a fixed amount of time, regardless of whether they are equal or not, ensuring that the comparison is secure and resistant to timing attacks. |
@@ -56,7 +44,7 @@ create table wbhtable (
 );
 ```
 
-## 3. Set up webhook in RudderStack
+## 2. Set up webhook in RudderStack
 
 After configuring RisingWave to accept webhook data, set up RudderStack to send events to your RisingWave instance.
 
@@ -108,11 +96,11 @@ Save and Activate the Destination:
 - Click **continue** to activate the webhook destination.
 </Step>
 </Steps>
-## 4. Push Data from RudderStack via Webhook
+## 3. Push Data from RudderStack via Webhook
 
 With the webhook configured, RudderStack will automatically send HTTP POST requests to your RisingWave webhook URL whenever there are data generated from the connected source. RisingWave will receive these requests, validate the signatures, and insert the payload data into the target table.
 
-## 5. Further event processing
+## 4. Further event processing
 
 The data in the table is already ready for further processing. You can access the fields using `data->'field_name'` in SQL queries.
 

--- a/integrations/sources/segment-webhook.mdx
+++ b/integrations/sources/segment-webhook.mdx
@@ -8,20 +8,7 @@ Segment is a Customer Data Platform (CDP) that collects event data from various 
 
 This guide will walk through the steps to set up RisingWave as a destination for Segment webhooks.
 
-## 1. Optional: Create a secret in RisingWave
-
-First, create a secret in RisingWave to securely store a secret string. This secret will be used to validate incoming webhook requests from Segment. This is the recommended way to verify the signature. You could also use a raw string to verify.
-
-```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'TEST_WEBHOOK';
-```
-
-| Parameter or clause | Description |
-| :--------- | :-----------|
-|`test_secret`| The name of the secret.|
-| `TEST_WEBHOOK`| The secret string used for signing and verifying webhook payloads. Replace this with a secure, random string.|
-
-## 2. Create a table in RisingWave
+## 1. Create a table in RisingWave
 
 Next, create a table configured to accept webhook data from Segment.
 
@@ -40,6 +27,7 @@ CREATE TABLE wbhtable (
 | Parameter or clause | Description |
 | :--------- | :-----------|
 | `data JSONB` | Defines the name of column to store the JSON payload from the webhook. Currently, only `JSONB` type is supported for webhook tables. |
+| `SECRET <secret>` | Use an existing [secret](/operate/manage-secrets) to verify incoming webhookd requests from Segment. This is optional. You can also use a raw string to verify.|
 | `headers->>'...'` | Extracts the signature provided by Segment in the `x-signature` HTTP header. <br/> <br/> In `secure_compare()` function, the whole HTTP header is interpreted as a JSONB object, and you can access the header value using the `->>` operator, but only the lower-case header names in the `->>` operator, otherwise the verification will fail. |
 | `encode(...)` | Computes the expected signature. In the example above, it generates an `HMAC SHA-1` hash of the payload (`data`) using the secret (`test_secret`), encodes it in hexadecimal. |
 | `secure_compare(...)` | Validates requests by matching the header signature against the computed signature, ensuring only authenticated requests are processed. The `secure_compare()` function compares two strings in a fixed amount of time, regardless of whether they are equal or not, ensuring that the comparison is secure and resistant to timing attacks. |
@@ -57,7 +45,7 @@ CREATE TABLE wbhtable (
 );
 ```
 
-## 3. Set up webhook in Segment
+## 2. Set up webhook in Segment
 
 After configuring RisingWave to accept webhook data, set up Segment to send events to your RisingWave instance.
 
@@ -104,11 +92,12 @@ Configure the webhook description on the **Mappings** tab.
 At the end of the page, you can send the test message via **Send test event**.
 Review your settings, click **Next** and specify a name.
 </Steps>
-## 4. Push data from Segment via webhook
+
+## 3. Push data from Segment via webhook
 
 With the webhook configured, Segment will automatically send HTTP POST requests to your RisingWave webhook URL whenever the specified events occur (e.g., pushes to the repository). RisingWave will receive these requests, validate the signatures, and insert the payload data into the target table.
 
-## 5. Further event processing
+## 4. Further event processing
 
 The data in the table is already ready for further processing. You can access the fields using `data->'field_name'` in SQL queries.
 

--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -16,7 +16,9 @@ This direct integration eliminates the need for an intermediary message broker l
 To utilize webhook sources in RisingWave, you need to create a table configured to accept webhook requests. Below is a basic example of how to set up such a table:
 
 ```sql
-CREATE SECRET test_secret WITH (backend = 'meta') AS 'secret_value';
+-- Create a secret to store the webhook validation key. Note that this is optional but recommended. 
+-- Alternatively you can use a raw string (without specifying `SECRET <secret>`).
+CREATE SECRET test_secret WITH (backend = 'meta') AS 'secret_value'; 
 
 CREATE TABLE wbhtable (
   data JSONB


### PR DESCRIPTION
# Documentation Update

## Description

Optional step for creating secrets are worded like it's mandatory. 

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
