### PR TITLE
Cloud: clarify NS_ID of project

### DIFF
--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -44,7 +44,7 @@ scrape_configs:
   static_configs:
   - targets:
     - {CLOUD_HOST}
-  metrics_path: /api/v1/tenant/{CLUSTER_ID}/metrics
+  metrics_path: /api/v2/tenants/{NS_ID}/metrics
   basic_auth:
     username: {API_KEY}
     password: {API_SECRET}
@@ -56,7 +56,7 @@ scrape_configs:
 #### Notes
 
 * Update the `Cloud_HOST` according to the region and Cloud provider of your RisingWave cluster.
-* Update the `CLUSTER_ID` with the specific cluster ID in your RisingWave environment. For example, if your cluster URL is `risingwave-cloud.com/cluster/168/us-central1/overview/`, replace `CLUSTER_ID` with the value `168`.
+* Update the `NS_ID` with the specific UUID of your RisingWave projects. To find the UUID, hover over the tag next to your project name.
 
 </Tab>
 <Tab title="DataDog">

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -56,7 +56,7 @@ scrape_configs:
 #### Notes
 
 * Update the `Cloud_HOST` according to the region and Cloud provider of your RisingWave cluster.
-* Update the `NS_ID` with the specific UUID of your RisingWave projects. To find the UUID, hover over the tag next to your project name.
+* Update the `NS_ID` with the specific UUID of your RisingWave project. To find the UUID, hover over the tag next to your project name.
 
 </Tab>
 <Tab title="DataDog">

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -66,7 +66,7 @@ Next, edit the `openmetrics.d/conf.yaml` file at the root of your [Agent configu
 
 ```yaml
 instances:
-- openmetrics_endpoint: http://{CLOUD_HOST}/api/v1/tenant/{CLUSTER_ID}/metrics
+- openmetrics_endpoint: http://{CLOUD_HOST}/api/v2/tenants/{NS_ID}/metrics
   namespace: risingwave
   metrics:
   - .*
@@ -78,7 +78,7 @@ instances:
 #### Notes
 
 * Update the `Cloud_HOST` according to the region and Cloud provider of your RisingWave cluster.
-* Update the `CLUSTER_ID` with the specific cluster ID in your RisingWave environment. For example, if your cluster URL is `risingwave-cloud.com/cluster/168/us-central1/overview/`, replace `CLUSTER_ID` with the value `168`.
+* Update the `NS_ID` with the specific UUID of your RisingWave project. To find the UUID, hover over the tag next to your project name.
 * The limit for the agent is **2000 metrics per instance**. To increase the limit, please contact [DataDog support](https://docs.datadoghq.com/help/).
 
 </Tab>


### PR DESCRIPTION
## Description

Clarify NS_ID of project, see [preview](https://risingwavelabs-wyx-cloud-cluster-id-.mintlify.app/cloud/export-metrics#step-3%3A-configure-monitoring-systems)


![image](https://github.com/user-attachments/assets/d0371fe6-9733-491b-98b2-f2df9a8b621e)
![image](https://github.com/user-attachments/assets/bd23348d-0b87-482c-ac5d-ddd7734cf7b4)

## Context

https://risingwave-labs.slack.com/archives/C0846L0TZDH/p1750402434684209

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
