### PR TITLE
Fix: clarify behavior of current_timestamp

### DIFF
--- a/sql/functions/datetime.mdx
+++ b/sql/functions/datetime.mdx
@@ -44,7 +44,7 @@ An interval can contain hour/minute/second (i.e., fixed length) but not year/mon
 
 ### `current_timestamp`
 
-Returns the current date and time.
+Returns the current date and time. For streaming queries, `now()` can only be used with WHERE, HAVING, and ON clauses. For more information, see [Temporal filters](/processing/sql/temporal-filters). This constraint does not apply to batch queries.
 
 ```sql
 current_timestamp() → *timestamptz*

--- a/sql/functions/datetime.mdx
+++ b/sql/functions/datetime.mdx
@@ -44,7 +44,8 @@ An interval can contain hour/minute/second (i.e., fixed length) but not year/mon
 
 ### `current_timestamp`
 
-Returns the current date and time. For streaming queries, `now()` can only be used with WHERE, HAVING, and ON clauses. For more information, see [Temporal filters](/processing/sql/temporal-filters). This constraint does not apply to batch queries.
+Returns the current date and time. `current_timestamp` is an alias of [`now`](/sql/functions/datetime#now). For streaming queries, it can only be used with WHERE, HAVING, and ON clauses. For more information, see [Temporal filters](/processing/sql/temporal-filters). This constraint does not apply to batch queries.
+
 
 ```sql
 current_timestamp() → *timestamptz*


### PR DESCRIPTION
## Description

Clarify behavior of current_timestamp

## Context

https://risingwave-labs.slack.com/archives/C081P87RWAK/p1750435654712569

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
