### PR TITLE
Cloud: update the metrics scraping configs of Prometheus, update the

### DIFF
--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -102,4 +102,4 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 
 To set up dashboards with **Grafana** and **Prometheus**, please follow the [Grafana dashboard build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with multiple namespace support.
 
-For other systems, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.
+For custom Grafana dashboards, or to generate them programmatically, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -102,4 +102,4 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 
 To set up dashboards with **Grafana** and **Prometheus**, please follow the [Grafana dashboard build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with multiple namespace support.
 
-For custom Grafana dashboards, or to generate them programmatically, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.
+For other systems, or to generate them programmatically, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -100,6 +100,6 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 
 ## Step 4: Set up dashboards
 
-To set up dashboards with **Grafana** and **Prometheus** data sources, please follow the [Grafana dashboards build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with mutliple namespace support.
+To set up dashboards with **Grafana** and **Prometheus** data sources, please follow the [Grafana dashboards build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with multiple namespace support.
 
 For other systems, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -41,6 +41,14 @@ To import the metrics to Prometheus, edit the `scrape_configs` section in the pr
 ```yaml
 scrape_configs:
 - job_name: risingwave-remote
+  relabel_configs:
+  - target_label: namespace
+    regex: {NS_ID}
+  - target_label: risingwave_name
+    regex: risingwave
+  - target_label: risingwave_component
+    source_labels:
+    - component
   static_configs:
   - targets:
     - {CLOUD_HOST}
@@ -92,4 +100,4 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 
 ## Step 4: Set up dashboards
 
-To set up dashboards based on key metrics, see [RisingWave open source user-dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py).
+To set up dashboards with **Grafana** and **Prometheus** data sources, please follow the [Grafana dashboards build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with mutliple namespace support.

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -101,3 +101,5 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 ## Step 4: Set up dashboards
 
 To set up dashboards with **Grafana** and **Prometheus** data sources, please follow the [Grafana dashboards build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with mutliple namespace support.
+
+For other systems, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.

--- a/cloud/export-metrics.mdx
+++ b/cloud/export-metrics.mdx
@@ -100,6 +100,6 @@ In the Telegraf configuration, you need to fill in the Prometheus input section,
 
 ## Step 4: Set up dashboards
 
-To set up dashboards with **Grafana** and **Prometheus** data sources, please follow the [Grafana dashboards build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with multiple namespace support.
+To set up dashboards with **Grafana** and **Prometheus**, please follow the [Grafana dashboard build instructions](https://github.com/risingwavelabs/risingwave/blob/main/grafana/README.md) to build a set of dashboards with multiple namespace support.
 
 For other systems, please refer to [the script for generating the Grafana user-facing dashboard](https://github.com/risingwavelabs/risingwave/blob/main/grafana/risingwave-user-dashboard.dashboard.py) and build your own.


### PR DESCRIPTION
dashboard setup instructions

## Description

- Update the metric import config of Prometheus to include several important labels.
- Update the dashboard setup instructions to clarify the two different ways of building dashboards
  - Grafana + Prometheus
  - Others

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
