### PR TITLE
Fix: add AWS Glue Schema Registry for Kafka sink

### DIFF
--- a/get-started/rw-premium-edition-intro.mdx
+++ b/get-started/rw-premium-edition-intro.mdx
@@ -39,7 +39,7 @@ The [**Elastic disk cache**](/get-started/disk-cache) feature harnesses modern h
 
 - [Automatic schema changes for PostgreSQL CDC](/ingestion/sources/postgresql/pg-cdc#automatic-schema-changes)
 - [Automatic schema changes for MySQL CDC](/ingestion/sources/mysql/mysql-cdc#automatic-schema-changes)
-- [AWS Glue Schema Registry](/ingestion/sources/kafka-config#read-schemas-from-aws-glue-schema-registry)
+- [AWS Glue Schema Registry for Kafka Source](/ingestion/sources/kafka-config#use-aws-glue-schema-registry) and [Kafka Sink](/integrations/destinations/apache-kafka#use-aws-glue-schema-registry)
 
 ### Connectors
 

--- a/ingestion/sources/kafka-config.mdx
+++ b/ingestion/sources/kafka-config.mdx
@@ -91,7 +91,7 @@ These parameters are used with `FORMAT` and `ENCODE` to specify how RisingWave s
 | *external_id*         | Optional. The [external](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) id used to authorize access to third-party resources.                                                                                       |
 | `map.handling.mode`   | For Avro data. How to ingest Avro map type to RisingWave. Available values: `'map'` (default) and `'jsonb'`.                                                                                                                                                                   |
 
-## Read schemas from AWS Glue Schema Registry
+## Use AWS Glue Schema Registry
 
 <Tip>
 **PREMIUM EDITION FEATURE**
@@ -103,7 +103,7 @@ For a full list of Premium Edition features, see [RisingWave Premium Edition](/g
 
 AWS Glue Schema Registry is a serverless feature of AWS Glue that allows you to centrally manage and enforce schemas for data streams, enabling data validation and compatibility checks. It helps in improving the quality of data streams by providing a central repository for managing and enforcing schemas across various AWS services and custom applications.
 
-You can specify the following configurations in the `ENCODE AVRO (...)` clause to read schemas from Glue.
+You can specify the following configurations in the `FORMAT PLAIN ENCODE AVRO (...)` or `FORMAT UPSERT ENCODE AVRO (...)` clause to read schemas from Glue.
 
 **Auth-related configurations**:
 

--- a/integrations/destinations/apache-kafka.mdx
+++ b/integrations/destinations/apache-kafka.mdx
@@ -117,6 +117,47 @@ ENCODE AVRO (
 
 For data type mapping, the serial type is supported. We map the serial type to the 64-bit signed integer.
 
+#### Use AWS Glue Schema Registry
+
+<Tip>
+**PREMIUM EDITION FEATURE**
+
+This is a Premium Edition feature. All Premium Edition features are available out of the box without additional cost on RisingWave Cloud. For self-hosted deployments, users need to purchase a license key to access this feature. To purchase a license key, please contact sales team at [sales@risingwave-labs.com](mailto:sales@risingwave-labs.com).
+
+For a full list of Premium Edition features, see [RisingWave Premium Edition](/get-started/rw-premium-edition-intro). 
+</Tip>
+
+AWS Glue Schema Registry is a serverless feature of AWS Glue that allows you to centrally manage and enforce schemas for data streams, enabling data validation and compatibility checks. It helps in improving the quality of data streams by providing a central repository for managing and enforcing schemas across various AWS services and custom applications.
+
+You can specify the following configurations in the `FORMAT PLAIN ENCODE AVRO (...)` or `FORMAT UPSERT ENCODE AVRO (...)` clause. This allows RisingWave to load schemas from and encode metadata for AWS Glue Schema Registry, in addition to Confluent Schema Registry.
+
+**Auth-related configurations**:
+
+| Parameter             |Description   |
+| :-------------------- | :------------- |
+| `aws.region` | The region of the AWS Glue Schema Registry. For example, `us-west-2`. |
+| `aws.credentials.access_key_id`| Your AWS access key ID. |
+| `aws.credentials.secret_access_key` | Your AWS secret access key. |
+| `aws.credentials.role.arn` | The Amazon Resource Name (ARN) of the role to assume. For example, `arn:aws:iam::123456123456:role/MyGlueRole`. This IAM role shall be granted permissions for the action `glue:GetSchemaVersion`. |
+
+**ARN to the schema**:
+
+| Parameter             |Description   |
+| :-------------------- | :------------- |
+| `aws.glue.schema_arn` | The ARN of the schema in AWS Glue Schema Registry. For example, `'arn:aws:glue:ap-southeast-1:123456123456:schema/default-registry/MyEvent'`. |
+
+```sql Example
+ENCODE AVRO (
+  aws.glue.schema_arn = 'arn:aws:glue:ap-southeast-1:123456123456:schema/default-registry/MyEvent',
+  aws.region = 'US-WEST-2',
+  aws.credentials.access_key_id = 'your_access_key_id',
+  aws.credentials.secret_access_key = 'your_secret_access_key',
+  aws.credentials.role.arn = 'arn:aws:iam::123456123456:role/MyGlueRole'
+  ...
+) [KEY ENCODE [TEXT | BYTES]] -- when specifying `primary_key` as Kafka key
+```
+
+
 ### Protobuf specific parameters
 
 When creating an append-only Protobuf sink, the following options can be used following `FORMAT PLAIN ENCODE PROTOBUF` or `FORMAT UPSERT ENCODE PROTOBUF`.


### PR DESCRIPTION
## Description

Add the missing part for Kafka sink, let me know if any comments.
Context: https://risingwave-labs.slack.com/archives/C03L8DNMDDW/p1752590403281289

## Related code PR

Sink: https://github.com/risingwavelabs/risingwave/pull/20181
Source: https://github.com/risingwavelabs/risingwave/pull/17605

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/568

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
