### PR TITLE
Fix: Iceberg sink parameter

### DIFF
--- a/iceberg/byoi/write-to-iceberg.mdx
+++ b/iceberg/byoi/write-to-iceberg.mdx
@@ -247,9 +247,12 @@ WITH (
     table.name = 'events',
     catalog.type = 'rest',
     catalog.uri = 'http://catalog-service:8181',
-    gcs.service.account = 'path/to/service-account.json'
+    gcs.credential = 'xxxxx'
 );
 ```
+<Note>
+`gcs.credential` is base64-encoded credential key obtained from the GCS service account key JSON file. To get this JSON file, refer to the [guides of GCS documentation](https://cloud.google.com/iam/docs/keys-create-delete#iam-service-account-keys-create-console). <ul><li>To encode it in base64, run the following command: <code>cat ~/Downloads/rwc-byoc-test-464bdd851bce.json &#124; base64 -b 0 &#124; pbcopy</code>, and then paste the output as the value for this parameter.</li><li>If this field is not specified, ADC (application default credentials) will be used.</li></ul>
+</Note>
 
 ### Azure Blob Storage
 


### PR DESCRIPTION
## Description

Remove `gcs.service.account` and clarify `gcs.credential`

## Context
https://risingwave-labs.slack.com/archives/C034XCYJPSN/p1752824811955229

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
