### PR TITLE
Fix: Hosted Iceberg Catalog doc align with code

### DIFF
--- a/iceberg/managed/hosted-iceberg-catalog.mdx
+++ b/iceberg/managed/hosted-iceberg-catalog.mdx
@@ -61,7 +61,7 @@ CREATE CONNECTION iceberg_catalog WITH (
 );
 
 -- Step 2: Set the connection as the default for the Iceberg engine
-SET rw_iceberg_connection = 'iceberg_catalog';
+SET iceberg_engine_connection = 'public.iceberg_catalog';
 
 -- Step 3: Create an Iceberg table 
 CREATE TABLE user_behaviors (


### PR DESCRIPTION
## Description

As title

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/596

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
