### PR TITLE
Fix: typo in azblob doc

### DIFF
--- a/deploy/risingwave-kubernetes.mdx
+++ b/deploy/risingwave-kubernetes.mdx
@@ -247,29 +247,28 @@ spec:
   stateStore:
     # Prefix to objects in the object stores or directory in file system. Default to "hummock".
     dataDirectory: hummock
-
-    # Declaration of the Google Cloud Storage state store backend.
+    
+    # Declaration of the Azure Blob Storage state store backend.
     azureBlob:
       # Endpoint of the Azure Blob service.
       endpoint: https://you-blob-service.blob.core.windows.net
-
+      
       # Working directory root of the Azure Blob service.
       root: risingwave
-
+      
       # Container name of the Azure Blob service.
       container: risingwave
-
-      # Credentials to access the Google Cloud Storage bucket.
+    
+      # Credentials to access the Azure Blob Storage container.
       credentials:
         # Name of the Kubernetes secret that stores the credentials.
-        secretName: gcs-credentials
-
+        secretName: azure-credentials
+        
         # Key of the account name in the secret.
         accountNameRef: AccountName
-
+        
         # Key of the account name in the secret.
         accountKeyRef: AccountKey
-
 ```
 </Tab>
 <Tab title="Google Cloud Storage">

--- a/deploy/risingwave-kubernetes.mdx
+++ b/deploy/risingwave-kubernetes.mdx
@@ -247,26 +247,26 @@ spec:
   stateStore:
     # Prefix to objects in the object stores or directory in file system. Default to "hummock".
     dataDirectory: hummock
-    
+
     # Declaration of the Azure Blob Storage state store backend.
     azureBlob:
       # Endpoint of the Azure Blob service.
       endpoint: https://you-blob-service.blob.core.windows.net
-      
+
       # Working directory root of the Azure Blob service.
       root: risingwave
-      
+
       # Container name of the Azure Blob service.
       container: risingwave
-    
+
       # Credentials to access the Azure Blob Storage container.
       credentials:
         # Name of the Kubernetes secret that stores the credentials.
         secretName: azure-credentials
-        
+
         # Key of the account name in the secret.
         accountNameRef: AccountName
-        
+
         # Key of the account name in the secret.
         accountKeyRef: AccountKey
 ```


### PR DESCRIPTION
## Description

Azblob doc aligned with code

## Related code

https://github.com/risingwavelabs/risingwave-operator/blob/b8b4e9fef61dca92bb303ada2d9006512ef79e35/docs/general/state-stores.md?plain=1#L163

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
