### PR TITLE
Fix: broken link in subscription.mdx

### DIFF
--- a/serve/subscription.mdx
+++ b/serve/subscription.mdx
@@ -200,7 +200,7 @@ fetch next from cur2;
 
 ## Subscribing via Postgres driver
 
-For this feature, you only need to use [the Postgres driver](https://docs.risingwave.com/docs/dev/client-libraries-overview/), and no extra dependencies are required.
+For this feature, you only need to use [the Postgres driver](/client-libraries/overview), and no extra dependencies are required.
 
 Here’s an example using Python and [psycopg2](https://pypi.org/project/psycopg2/).
 


### PR DESCRIPTION
## Description

As title

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/649

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
