### PR TITLE
Fix: clarify `changelog_op` types and mapping

### DIFF
--- a/integrations/destinations/snowflake.mdx
+++ b/integrations/destinations/snowflake.mdx
@@ -128,7 +128,7 @@ Snowpipe only ingests new rows; it does **not** apply updates or deletes.
 To surface those changes, you need to create a materialized view using `AS CHANGELOG` in RisingWave.  
 This instructs RisingWave to add two metadata columns to each change log row:
 
-* `changelog_op`: the change type (`1` = INSERT, `2` = DELETE, `3` = UPDATE-AFTER, `4` = UPDATE-BEFORE)  
+* `changelog_op`: the change type (`1` = Insert, `2` = Delete, `3` = UpdateInsert, `4` = UpdateDelete)  
 * `_changelog_row_id`: a monotonically increasing identifier that captures the order of the change
 
 You can rename these columns (for example, to `__op` and `__row_id`) in the `SELECT` list so they appear in the Snowflake sink.

--- a/sql/commands/sql-as-changelog.mdx
+++ b/sql/commands/sql-as-changelog.mdx
@@ -5,6 +5,11 @@ description: "Use the `AS CHANGELOG` clause to convert a changelog operation in 
 
 This can be used to create materialized views and sinks. See the practice in [Sink data with upsert in Snowflake](/integrations/destinations/snowflake#sink-data-with-upsert).
 
+The AS CHANGELOG clause adds two metadata columns:
+
+- `changelog_op`: the change type (`1` = Insert, `2` = Delete, `3` = UpdateInsert, `4` = UpdateDelete)  
+- `_changelog_row_id`: a monotonically increasing identifier that captures the order of the change.
+
 ## Syntax
 
 ```sql


### PR DESCRIPTION
## Description

As title

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/656

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
