### PR TITLE
Document: add `has_database_privilege()`

### DIFF
--- a/sql/functions/sys-admin.mdx
+++ b/sql/functions/sys-admin.mdx
@@ -80,6 +80,24 @@ SELECT has_function_privilege('test_user', 'foo_func(int)', 'EXECUTE');
 t
 ```
 
+## `has_database_privilege()`
+
+<Note>
+Added in v2.6.0.
+</Note>
+
+Checks if a user has access to a database. If no user is provided, it assumes the current user.
+
+```sql Syntax
+has_database_privilege([user], database, privilege); -> boolean
+```
+
+```sql Example
+SELECT has_database_privilege('test_user', 'test_db', 'CONNECT');
+----RESULT
+t
+```
+
 ## `rw_recovery_status()`
 
 Retrieves the current recovery status of the cluster. The return values can be one of `STARTING`, `RECOVERING`, or `RUNNING`.


### PR DESCRIPTION
## Description

Add `has_database_privilege()` system admin function

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/22576

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/641

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
