### PR TITLE
Document: add composite version columns

### DIFF
--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -161,7 +161,7 @@ When a row is updated only with a new version number and other columns remain un
     automatically compact "no-op" updates to prevent massive updates for downstream jobs. You can create a logical view with `SELECT * EXCEPT(version_col)` to avoid depending on the version column by mistake.
 </Note>
 
-**Multiple version columns**
+**Composite version columns**
 
 <Note>
 Added in v2.6.0.

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -149,7 +149,8 @@ When `DO UPDATE IF NOT NULL` behavior is applied, `DEFAULT` clause is not allowe
 
 A version column is a non-primary-key column that can be used with `OVERWRITE` and `DO UPDATE IF NOT NULL` to tune the conflict handling behaviors.
 
-Common use cases include:
+**Common use cases**
+
 1. Use an event time column as the version column to ensure temporal ordering and ignore late-arriving data.
 2. Use an integer as a logical version number. You can use an Upsert-then-Delete pattern with a logical version column to implement "zero-downtime incremental version upgrade" for data in the table: you insert a new version of data with a higher version number while keeping old data, and then after finishing the upgrade, you clean up old data with a `DELETE` statement.
 
@@ -159,6 +160,30 @@ Common use cases include:
 When a row is updated only with a new version number and other columns remain unchanged, downstream streaming jobs that don’t use the version column won’t be affected. RisingWave will
     automatically compact "no-op" updates to prevent massive updates for downstream jobs. You can create a logical view with `SELECT * EXCEPT(version_col)` to avoid depending on the version column by mistake.
 </Note>
+
+**Multiple version columns**
+
+<Note>
+Added in v2.6.0.
+</Note>
+
+RisingWave supports specifying multiple version columns to enable more sophisticated conflict-resolution strategies for CDC and upsert scenarios.
+
+```sql Syntax
+CREATE TABLE t (
+  id INT,
+  v1 INT,
+  v2 VARCHAR,
+  data TEXT,
+  PRIMARY KEY(id)
+)
+ON CONFLICT DO UPDATE IF NOT NULL
+WITH VERSION COLUMN(v1, v2);
+```
+
+When conflicts occur, the specified columns are compared lexicographically (from left to right) to determine which row should be kept.
+
+For example, with `version_column(v1, v2)`, a new row with `(v1=2, v2=1)` will override an existing row with `(v1=1, v2=5)` because `v1=2` > `v1=1`.
 
 ## Example
 

--- a/sql/commands/sql-create-table.mdx
+++ b/sql/commands/sql-create-table.mdx
@@ -167,7 +167,7 @@ When a row is updated only with a new version number and other columns remain un
 Added in v2.6.0.
 </Note>
 
-RisingWave supports specifying multiple version columns to enable more sophisticated conflict-resolution strategies for CDC and upsert scenarios.
+RisingWave supports specifying composite version columns in the `VERSION COLUMN` clause.
 
 ```sql Syntax
 CREATE TABLE t (


### PR DESCRIPTION
## Description

Support syntax of composite version columns when creating table

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/22931

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/634

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
