### PR TITLE
Document: add Iceberg REST Catalog with Lakekeeper

### DIFF
--- a/iceberg/hosted-iceberg-catalog.mdx
+++ b/iceberg/hosted-iceberg-catalog.mdx
@@ -1,58 +1,19 @@
 ---
 title: Hosted Iceberg catalog
-sidebarTitle: "Hosted Iceberg catalog"
-description: "Learn how to use the hosted Iceberg catalog in RisingWave. This guide shows you how to create and manage Iceberg tables without the need to configure or maintain an external catalog service like AWS Glue or a JDBC database."
+sidebarTitle: "Overview"
+description: "Discover hosted Iceberg catalog options and usage in RisingWave."
 ---
-The Hosted Iceberg Catalog is a built-in catalog service for the Iceberg table engine. It simplifies the process of creating Iceberg tables by eliminating the need to set up, configure, and manage an external catalog service like AWS Glue, a separate JDBC database, or a REST service.
+
+The hosted Iceberg catalog is a built-in catalog service for the Iceberg table engine. It simplifies the process of creating Iceberg tables by eliminating the need to set up, configure, and manage an external catalog service like AWS Glue, a separate JDBC database, or a REST service.
+
 For users new to Iceberg, or for those who want to reduce operational overhead, the hosted catalog provides the quickest way to get started with the Iceberg table engine in RisingWave.
 
-## How it works
+## Hosted catalog options
 
-When you enable the hosted catalog in an Iceberg connection, RisingWave utilizes its internal metastore (which is typically a PostgreSQL instance) to function as a standard Iceberg JDBC Catalog.
+RisingWave supports the following types of hosted catalogs:
 
-- Table metadata for tables created with the `ENGINE = iceberg` clause is stored within two system views in RisingWave: `iceberg_tables` and `iceberg_namespace_properties`.
-- This implementation is not a proprietary format; it adheres to the standard Iceberg JDBC Catalog protocol.
-- This ensures that the tables remain open and accessible to external tools like Spark, Trino, and Flink that can connect to a JDBC catalog.
-
-## Create a connection with the hosted catalog
-
-To use the hosted catalog, you create an Iceberg connection and set the `hosted_catalog` parameter to `true`.
-
-
-### Syntax 
-
-```sql
-CREATE CONNECTION connection_name
-WITH (
-    type = 'iceberg',
-    warehouse.path = '<storage_path>',
-    <object_storage_parameters>,
-    hosted_catalog = true
-);
-```
-
-Where `<storage_path>` and `<object_storage_parameters>` depend on your chosen storage backend (S3, GCS, or Azure Blob). See the [object storage configuration](/iceberg/object-storage) for specific parameter details.
-
-### Parameters
-
-For object storage configuration parameters, see [Object storage configuration](/iceberg/object-storage).
-
-#### Hosted catalog-specific parameters
-
-| Field | Description |
-|-------|-------------|
-| `hosted_catalog` | **Required**. Set to true to enable the Hosted Iceberg Catalog for this connection. This instructs RisingWave to manage the catalog metadata internally. |
-
-## Create your first table
-
-Now that you understand how to configure a connection with the hosted catalog, the next step is to create a table and start streaming data. For a complete, step-by-step guide, please follow our quickstart tutorial.
-
-<Card
-  title="Quickstart: Create a streaming Iceberg table"
-  href="/iceberg/quickstart-create-table"
->
-  This tutorial walks you through creating your first native Iceberg table from scratch using the hosted catalog.
-</Card>
+- **[JDBC hosted catalog](/iceberg/iceberg-catalog-jdbc)** – backed by RisingWave’s internal PostgreSQL-compatible metastore.  
+- **[REST hosted catalog](/iceberg/iceberg-catalog-rest)** – powered by [Lakekeeper](https://lakekeeper.io), a REST service that manages Iceberg metadata.
 
 ## Benefits of the hosted catalog
 
@@ -61,50 +22,6 @@ Now that you understand how to configure a connection with the hosted catalog, t
 - **Standard compliance**: Uses the standard Iceberg JDBC catalog protocol for compatibility
 - **External accessibility**: Tables can be accessed by external Iceberg-compatible tools
 - **Reduced complexity**: Fewer moving parts in your data architecture
-
-## External access to hosted catalog tables
-
-Since the hosted catalog implements the standard Iceberg JDBC catalog protocol, external tools can access your tables by connecting to RisingWave's metastore.
-
-### Spark example
-
-```scala
-import org.apache.spark.sql.SparkSession
-
-val spark = SparkSession.builder()
-  .appName("AccessRisingWaveIcebergTables")
-  .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
-  .config("spark.sql.catalog.risingwave_catalog", "org.apache.iceberg.spark.SparkCatalog")
-  .config("spark.sql.catalog.risingwave_catalog.type", "jdbc")
-  .config("spark.sql.catalog.risingwave_catalog.uri", "jdbc:postgresql://risingwave-host:4566/dev")
-  .config("spark.sql.catalog.risingwave_catalog.jdbc.user", "root")  
-  .config("spark.sql.catalog.risingwave_catalog.jdbc.password", "your_password")
-  .config("spark.sql.catalog.risingwave_catalog.warehouse", "s3://my-iceberg-bucket/warehouse/")
-  .getOrCreate()
-
-// Query the table created in RisingWave
-spark.sql("SELECT * FROM risingwave_catalog.public.user_behaviors").show()
-```
-
-### Trino example
-
-Add this to your Trino catalog configuration:
-
-```properties
-# risingwave.properties
-connector.name=iceberg
-iceberg.catalog.type=jdbc
-iceberg.jdbc.url=jdbc:postgresql://risingwave-host:4566/dev
-iceberg.jdbc.user=root
-iceberg.jdbc.password=your_password
-```
-
-Then query from Trino:
-```sql
-SELECT behavior_type, COUNT(*) as count
-FROM risingwave.public.user_behaviors  
-GROUP BY behavior_type;
-```
 
 ## When to use external catalogs instead
 

--- a/iceberg/iceberg-catalog-jdbc.mdx
+++ b/iceberg/iceberg-catalog-jdbc.mdx
@@ -1,0 +1,82 @@
+---
+title: Hosted Iceberg catalog
+sidebarTitle: "JDBC"
+description: "Learn how to deploy RisingWave with a hosted JDBC catalog to manage Iceberg tables."
+---
+
+The JDBC hosted catalog allows you manage Iceberg tables directly inside RisingWave without running a separate catalog service. When you enable the hosted catalog in an Iceberg connection, RisingWave utilizes its internal metastore (which is typically a PostgreSQL instance) to function as a standard Iceberg JDBC Catalog.
+
+- Table metadata for tables created with the `ENGINE = iceberg` clause is stored within two system views in RisingWave: `iceberg_tables` and `iceberg_namespace_properties`.
+- This implementation is not a proprietary format; it adheres to the standard Iceberg JDBC Catalog protocol.
+- This ensures that the tables remain open and accessible to external tools like Spark, Trino, and Flink that can connect to a JDBC catalog.
+
+## Step 1. Create a connection
+
+To use the hosted catalog, you create an Iceberg connection and set the `hosted_catalog` parameter to `true`. This instructs RisingWave to manage the catalog metadata internally.
+
+```sql Syntax
+CREATE CONNECTION connection_name
+WITH (
+    type = 'iceberg',
+    warehouse.path = '<storage_path>',
+    <object_storage_parameters>,
+    hosted_catalog = true
+);
+```
+
+Where `<storage_path>` and `<object_storage_parameters>` depend on your chosen storage backend (S3, GCS, or Azure Blob). See the [object storage configuration](/iceberg/object-storage) for specific parameter details.
+
+## Step 2. Create your first table
+
+Now that you understand how to configure a connection with the hosted catalog, the next step is to create a table and start streaming data. For a complete, step-by-step guide, please follow our quickstart tutorial.
+
+<Card
+  title="Quickstart: Create a streaming Iceberg table"
+  href="/iceberg/quickstart-create-table"
+>
+  This tutorial walks you through creating your first native Iceberg table from scratch using the hosted catalog.
+</Card>
+
+## External access to hosted catalog tables
+
+Since the hosted catalog implements the standard Iceberg JDBC catalog protocol, external tools can access your tables by connecting to RisingWave's metastore.
+
+### Spark example
+
+```scala
+import org.apache.spark.sql.SparkSession
+
+val spark = SparkSession.builder()
+  .appName("AccessRisingWaveIcebergTables")
+  .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+  .config("spark.sql.catalog.risingwave_catalog", "org.apache.iceberg.spark.SparkCatalog")
+  .config("spark.sql.catalog.risingwave_catalog.type", "jdbc")
+  .config("spark.sql.catalog.risingwave_catalog.uri", "jdbc:postgresql://risingwave-host:4566/dev")
+  .config("spark.sql.catalog.risingwave_catalog.jdbc.user", "root")  
+  .config("spark.sql.catalog.risingwave_catalog.jdbc.password", "your_password")
+  .config("spark.sql.catalog.risingwave_catalog.warehouse", "s3://my-iceberg-bucket/warehouse/")
+  .getOrCreate()
+
+// Query the table created in RisingWave
+spark.sql("SELECT * FROM risingwave_catalog.public.user_behaviors").show()
+```
+
+### Trino example
+
+Add this to your Trino catalog configuration:
+
+```properties
+# risingwave.properties
+connector.name=iceberg
+iceberg.catalog.type=jdbc
+iceberg.jdbc.url=jdbc:postgresql://risingwave-host:4566/dev
+iceberg.jdbc.user=root
+iceberg.jdbc.password=your_password
+```
+
+Then query from Trino:
+```sql
+SELECT behavior_type, COUNT(*) as count
+FROM risingwave.public.user_behaviors  
+GROUP BY behavior_type;
+```

--- a/iceberg/iceberg-catalog-jdbc.mdx
+++ b/iceberg/iceberg-catalog-jdbc.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hosted Iceberg catalog
+title: Iceberg JDBC catalog
 sidebarTitle: "JDBC"
 description: "Learn how to deploy RisingWave with a hosted JDBC catalog to manage Iceberg tables."
 ---

--- a/iceberg/iceberg-catalog-rest.mdx
+++ b/iceberg/iceberg-catalog-rest.mdx
@@ -1,0 +1,211 @@
+---
+title: Iceberg REST Catalog with Lakekeeper
+sidebarTitle: "REST"
+description: "Learn how to deploy RisingWave with a hosted REST catalog to manage Iceberg tables."
+---
+
+This guide will help you deploy RisingWave together with Lakekeeper, a hosted REST catalog. With this setup, you can easily create an Iceberg table and ingest data into a REST catalog using RisingWave.
+
+Lakekeeper can be deployed in two ways:
+
+- **Docker** – quick and easy for local testing.  
+- **Kubernetes (Helm)** – recommended for production or cluster environments.  
+
+## Deploy Lakekeeper with Docker
+
+### Prerequisites
+
+1. Install [**Docker Desktop**](https://docs.docker.com/get-docker/) in your environment, ensure that it is running before launching the cluster.
+
+2. Clone the [**risingwave**](https://github.com/risingwavelabs/risingwave) repository.
+
+    ```bash
+    git clone https://github.com/risingwavelabs/risingwave.git
+    ```
+
+3. Open the repository in a terminal and run the following command to navigate to the `docker` directory.
+
+    ```bash
+    cd docker
+    ```
+
+4. Run the `docker compose` command to deploy a RisingWave cluster and the Lakekeeper catalog. A default warehouse named **`risingwave-warehouse`** will be registered in Lakekeeper. Once Docker is up, you can view its configuration details at `http://localhost:8181/ui/warehouse`.
+
+    ```bash
+    docker compose -f docker-compose-with-lakekeeper.yml up
+    ```
+
+5. You can then start creating first iceberg table in the catalog via risingwave.
+
+    ```bash
+    psql -h localhost -p 4566 -d dev -U root
+    ```
+
+### Steps
+
+1. First, create an Iceberg connection
+
+    ```sql
+    CREATE CONNECTION lakekeeper_catalog_conn
+    WITH (
+        type = 'iceberg',
+        catalog.type = 'rest',
+        catalog.uri = 'http://lakekeeper:8181/catalog/',
+        warehouse.path = 'risingwave-warehouse',
+        s3.access.key = 'hummockadmin',
+        s3.secret.key = 'hummockadmin',
+        s3.path.style.access = 'true',
+        s3.endpoint = 'http://minio-0:9301',
+        s3.region = 'us-east-1'
+    );
+    ```
+
+2. Set the connection as Iceberg engine default connection
+
+    ```sql
+    SET iceberg_engine_connection = 'public.lakekeeper_catalog_conn';
+    ALTER SYSTEM SET iceberg_engine_connection = 'public.lakekeeper_catalog_conn';
+    ```
+
+3. Create an Iceberg table
+
+    ```sql
+    CREATE TABLE t_lakekeeper_basic(
+        id INT PRIMARY KEY,
+        name VARCHAR,
+        v BIGINT
+    )
+    WITH (commit_checkpoint_interval = 1)
+    ENGINE = iceberg;
+    ```
+
+4. Insert some data
+
+    ```sql
+    INSERT INTO t_lakekeeper_basic VALUES
+        (1, 'alice', 100),
+        (2, 'bob', 200),
+        (3, 'charlie', 300);
+    FLUSH;
+    ```
+
+5. Query the iceberg table
+
+    ```sql
+    SELECT * FROM t_lakekeeper_basic;
+    ```
+
+## Deploy Lakekeeper with Kubernetes (Helm)
+
+### Prerequisites
+
+Before proceeding with this guide, you should first set up your Kubernetes environment with Helm by following the [instructions](/deploy/risingwave-k8s-helm).
+
+### Steps
+
+1. Configure Helm (3.10+ required, 3.18+ preferred)
+
+    ```bash
+    helm repo add risingwavelabs https://risingwavelabs.github.io/helm-charts/ --force-update
+    helm repo add lakekeeper https://lakekeeper.github.io/lakekeeper-charts/
+    helm repo update
+    ```
+
+2. Create a namespace
+
+    ```bash
+    kubectl create namespace risingwave
+    ```
+
+3. Install RisingWave (with bundled PostgreSQL + MinIO)
+
+    ```bash
+    helm install -n risingwave --set tags.bundle=true risingwavelabs/risingwave
+    ```
+
+4. Install Lakekeeper (with bundled PG)**
+
+    ```bash
+    helm install -n risingwave my-lakekeeper lakekeeper/lakekeeper
+    ```
+
+5. Verify pods
+
+    ```bash
+    kubectl get pods -n risingwave
+    ```
+
+    Example output:
+
+    ```
+    NAME                                    READY   STATUS      RESTARTS   AGE
+    my-lakekeeper-57448667f6-cmd5h          1/1     Running     0          26m
+    my-lakekeeper-db-migration-1-qkgft      0/1     Completed   0          26m
+    my-lakekeeper-lakekeeper-pg-0           1/1     Running     0          26m
+    risingwave-compactor-74bd46489f-8wt4n   1/1     Running     0          21m
+    risingwave-compute-0                    1/1     Running     0          21m
+    risingwave-frontend-7cd89c7c4b-q5kv7    1/1     Running     0          21m
+    risingwave-meta-0                       1/1     Running     0          21m
+    risingwave-minio-5d86bdd9dd-dkpw7       1/1     Running     0          21m
+    risingwave-postgresql-0                 1/1     Running     0          21m
+    ```
+
+6. Get MinIO password
+
+    ```bash
+    k get secret risingwave-minio -o jsonpath="{.data['root-password']}" | base64 -d
+    ```
+
+7. Forward ports (run each in a separate terminal)
+
+    ```bash
+    kubectl -n risingwave port-forward svc/risingwave 4567
+    kubectl -n risingwave port-forward svc/risingwave-minio 9001
+    kubectl -n risingwave port-forward svc/my-lakekeeper 8181
+    ```
+
+8. Configure MinIO and Lakekeeper
+
+    <Note>
+    This guide uses **MinIO** as an example. If you need to use another object store, such as **S3**, you can configure it accordingly in the Lakekeeper UI.
+    </Note>
+
+    Open a browser to `http://localhost:9001` and create a bucket (e.g., "abc"), then open a browser to `http://localhost:8181` and create a warehouse (e.g., "abc").
+
+    - For the **Access key**, enter `root`;
+    - For the **Password**, use the one you obtained earlier;
+    - Enable the **Path style** toggle;
+    - The **Region** can be anything, typically `us-east-1`.
+
+    
+
+9. Connect RisingWave and test SQL
+
+    ```bash Connect to RisingWave
+    psql -h localhost -p 4567 -d dev -U root
+    ```
+
+    ```sql Run SQL
+    create connection lakekeeper_catalog_conn
+    with (
+        type = 'iceberg',
+        catalog.type = 'rest',
+        catalog.uri = 'http://my-lakekeeper:8181/catalog/',
+        warehouse.path = 'abc',       -- replace the warehouse name here
+        s3.access.key = 'root',
+        s3.secret.key = 'K9xXOGgEHx', -- replace the secret key here
+        s3.path.style.access = 'true',
+        s3.endpoint = 'http://risingwave-minio:9000',
+        s3.region = 'us-east-1'
+    );
+
+    set iceberg_engine_connection = 'public.lakekeeper_catalog_conn';
+
+    create table t_lakekeeper_basic(id int primary key, name varchar, v bigint)
+    with(commit_checkpoint_interval = 1) engine = iceberg;
+
+    insert into t_lakekeeper_basic values(1, 'alice', 100), (2, 'bob', 200), (3, 'charlie', 300);
+    flush;
+
+    select * from t_lakekeeper_basic;
+    ```

--- a/mint.json
+++ b/mint.json
@@ -218,7 +218,14 @@
           "pages": [
             "iceberg/quickstart-create-table",
             "iceberg/create-manage-native-iceberg-tables",
-            "iceberg/hosted-iceberg-catalog"
+            {
+              "group": "Hosted Iceberg catalog",
+              "pages": [
+                "/iceberg/hosted-iceberg-catalog",
+                "/iceberg/iceberg-catalog-jdbc",
+                "/iceberg/iceberg-catalog-rest"
+              ]
+            }
           ]
         },
         {


### PR DESCRIPTION
## Description

1. Restructure hosted iceberg catalog, see preview of [overview](https://risingwavelabs-wyx-hosted-iceberg-catalog.mintlify.app/iceberg/hosted-iceberg-catalog), [`jdbc`](https://risingwavelabs-wyx-hosted-iceberg-catalog.mintlify.app/iceberg/iceberg-catalog-jdbc) and [`rest`](https://risingwavelabs-wyx-hosted-iceberg-catalog.mintlify.app/iceberg/iceberg-catalog-rest)
2. For hosted rest catalog, introduce Lakekeeper and how to deploy it via docker compose and k8s

Let me know if any other user-facing info is required

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/23045

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/644

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
