### PR TITLE
Document: `hashicorp_vault` as backend when creating secret

### DIFF
--- a/operate/manage-secrets.mdx
+++ b/operate/manage-secrets.mdx
@@ -22,12 +22,10 @@ This is a premium feature. For a comprehensive overview of all premium features 
 
 ## Create secrets
 
-You can use the following statement to create secrets:
-
-Syntax for creating secrets
+You can use the following statement to create secrets. For detailed syntax, parameters, and examples, see [CREATE SECRET](/sql/commands/sql-create-secret).
 
 ```sql
-CREATE SECRET secret_name WITH ( backend = 'meta') AS 'your_secret';
+CREATE SECRET secret_name WITH ( backend = 'meta' | 'hashicorp_vault' ) AS ...;
 ```
 
 Examples
@@ -37,10 +35,6 @@ CREATE SECRET mysql_pwd WITH (
   backend = 'meta'
 ) AS '123';
 ```
-
-<Note>
-Currently only the meta backend is supported.
-</Note>
 
 ## Use secrets
 

--- a/operate/manage-secrets.mdx
+++ b/operate/manage-secrets.mdx
@@ -25,7 +25,7 @@ This is a premium feature. For a comprehensive overview of all premium features 
 You can use the following statement to create secrets. For detailed syntax, parameters, and examples, see [CREATE SECRET](/sql/commands/sql-create-secret).
 
 ```sql
-CREATE SECRET secret_name WITH ( backend = 'meta' | 'hashicorp_vault' ) AS ...;
+CREATE SECRET secret_name WITH ( backend = 'meta' | 'hashicorp_vault' ) AS [<secret in plaintext>];
 ```
 
 Examples

--- a/sql/commands/sql-create-secret.mdx
+++ b/sql/commands/sql-create-secret.mdx
@@ -11,21 +11,60 @@ This is a premium feature. For a comprehensive overview of all premium features 
 
 ## Syntax
 
-```sql
-CREATE SECRET secret_name WITH ( backend = 'meta') AS 'your_secret';
+```sql meta as backend
+CREATE SECRET secret_name WITH ( backend = 'meta' ) AS 'your_secret';
+```
+
+```sql hashicorp_vault as backend
+CREATE SECRET secret_name
+WITH (
+  backend = 'hashicorp_vault',
+  addr = '<Vault server address>',
+  path = '<Vault KV path>',
+  field = '<field_to_extract>',
+  auth_method = '<token|approle>',
+  -- For token authentication:
+  auth_token = '<vault_token>',
+  -- For approle authentication:
+  auth_role_id = '<role_id>',
+  auth_secret_id = '<secret_id>',
+  tls_skip_verify = 'true'
+) AS NULL;
 ```
 
 ## Parameters
 
+### General
+
 | Parameter or Clause | Description                                                                                           |
 | :------------------ | :---------------------------------------------------------------------------------------------------- |
-| _secret\_name_      | The name of the secret to be created. This should be a unique identifier within the system.           |
-| _backend_           | Specifies the backend where the secret will be stored. Currently, only the meta backend is supported. |
-| _your\_secret_      | The secret value that you wish to store securely.                                                     |
+| secret_name      | The name of the secret to be created. This should be a unique identifier within the system.           |
+| backend           | Specifies the backend where the secret will be stored. Supported backend options are `hashicorp_vault`(since v2.6.0) and `meta`. |
+
+### meta as backend
+| Parameter or Clause | Description                                                                                           |
+| :------------------ | :---------------------------------------------------------------------------------------------------- |
+| your_secret      | The secret value that you wish to store securely.                                                     |
+
+### hashicorp_vault as backend
+
+| Parameter or Clause | Description                                                                                           |
+| :------------------ | :---------------------------------------------------------------------------------------------------- |
+| addr | Address of the Vault server (e.g., `http://vault-server:8200`). |
+| path | Path to the secret in Vault KV store (e.g., `secret/data/myapp/db`). |
+| field | Optional. The field to extract from the secret (e.g., `password`). |
+| auth_method | Specify authentication methods. Supported methods are `token` (use Vault tokens for direct access) and `approle` (use role-based authentication for enhanced security).|
+| auth_token | Vault token (for token auth) |
+| auth_role_id | Role ID (for AppRole auth) |
+| auth_secret_id | Secret ID (for AppRole auth) |
+| tls_skip_verify | Optional. Disables TLS verification. |
+
 
 ## Examples
 
-Here is an example. We create a secret named `mysql_pwd`, and then use it in the `WITH` clause. After that, we use the `SHOW CREATE SOURCE` command to view the password. As shown in the result, the MySQL password is hidden, ensuring no secret leaks.
+### `meta` as backend
+
+We create a secret named `mysql_pwd`, and then use it in the `WITH` clause. After that, we use the `SHOW CREATE SOURCE` command to view the password. As shown in the result, the MySQL password is hidden, ensuring no secret leaks.
 
 ```sql
 CREATE SECRET mysql_pwd WITH ( backend = 'meta' ) AS '123';
@@ -48,6 +87,39 @@ SHOW CREATE SOURCE mysql_source;
 
 ---RESULT
 --- public.mysql_mydb | CREATE SOURCE mysql_mydb WITH (connector = 'mysql-cdc', hostname = 'mysql', port = '3306', username = 'root', password = secret mysql_pwd, database.name = 'mydb', server.id = '2') FORMAT PLAIN ENCODE JSON
+```
+
+### `hashicorp_vault` as backend
+
+Create the secret using token authentication:
+
+```sql
+CREATE SECRET vault_token_secret
+WITH (
+  backend = 'hashicorp_vault',
+  addr = 'http://vault-server:8200',
+  path = 'secret/data/myapp/db',
+  field = 'password',
+  auth_method = 'token',
+  auth_token = 'root-token',
+  tls_skip_verify = 'true'
+) AS NULL;
+```
+
+Create the secret using AppRole authentication:
+
+```sql
+CREATE SECRET approle_kafka_user
+WITH (
+  backend = 'hashicorp_vault',
+  addr = 'https://vault.example.com',
+  path = 'secret/data/myapp/kafka',
+  field = 'username',
+  auth_method = 'approle',
+  auth_role_id = '<your_role_id>',
+  auth_secret_id = '<your_secret_id>'
+) AS NULL;
+
 ```
 
 ## See also

--- a/sql/commands/sql-create-secret.mdx
+++ b/sql/commands/sql-create-secret.mdx
@@ -39,7 +39,7 @@ WITH (
 | Parameter or Clause | Description                                                                                           |
 | :------------------ | :---------------------------------------------------------------------------------------------------- |
 | secret_name      | The name of the secret to be created. This should be a unique identifier within the system.           |
-| backend           | Specifies the backend where the secret will be stored. Supported backend options are `hashicorp_vault`(since v2.6.0) and `meta`. |
+| backend           | Specifies the backend where the secret will be stored. Supported backend options are `hashicorp_vault` (since v2.6.0) and `meta`. |
 
 ### meta as backend
 | Parameter or Clause | Description                                                                                           |

--- a/sql/commands/sql-create-secret.mdx
+++ b/sql/commands/sql-create-secret.mdx
@@ -51,13 +51,14 @@ WITH (
 | Parameter or Clause | Description                                                                                           |
 | :------------------ | :---------------------------------------------------------------------------------------------------- |
 | addr | Address of the Vault server (e.g., `http://vault-server:8200`). |
-| path | Path to the secret in Vault KV store (e.g., `secret/data/myapp/db`). |
+| path | Path to the secret in Vault KV store (e.g., `secret/data/myapp/db`). Fetch the secret JSON from a URL such as `{addr}/v1/{path}` and get the `{field}` from JSON. |
 | field | Optional. The field to extract from the secret (e.g., `password`). |
 | auth_method | Specify authentication methods. Supported methods are `token` (use Vault tokens for direct access) and `approle` (use role-based authentication for enhanced security).|
 | auth_token | Vault token (for token auth) |
 | auth_role_id | Role ID (for AppRole auth) |
 | auth_secret_id | Secret ID (for AppRole auth) |
 | tls_skip_verify | Optional. Disables TLS verification. |
+| AS NULL | The AS clause has to be NULL. |
 
 
 ## Examples


### PR DESCRIPTION
## Description

See preview of [manage secrets](https://risingwavelabs-wyx-fix-663.mintlify.app/operate/manage-secrets) and [create secret command](https://risingwavelabs-wyx-fix-663.mintlify.app/sql/commands/sql-create-secret).

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/22627

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/663

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
