### PR TITLE
Fix: revert `alter subscription set parallelism`

### DIFF
--- a/sql/commands/sql-alter-subscription.mdx
+++ b/sql/commands/sql-alter-subscription.mdx
@@ -48,23 +48,6 @@ ALTER SUBSCRIPTION subscription_name
 ALTER SUBSCRIPTION sub0 RENAME TO sub1;
 ```
 
-### `SET PARALLELISM`
-
-```sql
-ALTER SUBSCRIPTION subscription_name
-SET PARALLELISM { TO | = } parallelism_number;
-```
-
-| Parameter or clause   | Description                                                                                                                                                                                                                                                                                                                              |
-| :-------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **SET PARALLELISM**   | This clause controls the degree of [parallelism](/reference/key-concepts#parallelism) for the targeted [streaming job](/reference/key-concepts#streaming-queries).                                                                                                                                                                  |
-| parallelism_number | Can be ADAPTIVE or a fixed number (e.g., 1, 2, 3). Setting it to ADAPTIVE expands the job's parallelism to all available units, while a fixed number locks it at that value. Setting it to 0 is equivalent to ADAPTIVE. The maximum allowed value is determined by the `max_parallelism` of the job. For more information, see [Configuring maximum parallelism](/deploy/k8s-cluster-scaling#configuring-maximum-parallelism). |
-
-```sql
--- Set the parallelism of the SUBSCRIPTION "s" to 4.
-ALTER SUBSCRIPTION s SET PARALLELISM = 4;
-```
-
 ### `SET SCHEMA`
 
 ```sql


### PR DESCRIPTION
## Description

Revert `alter subscription set parallelism` as subscription is no longer a streaming job

## Context

Previously: https://github.com/risingwavelabs/risingwave-docs/pull/88#issuecomment-2503123786
Currently: https://risingwave-labs.slack.com/archives/C034XCYJPSN/p1758324228100849

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
