### PR TITLE
Document: add Iceberg maintenance and write mode

### DIFF
--- a/iceberg/compaction.mdx
+++ b/iceberg/compaction.mdx
@@ -1,0 +1,29 @@
+---
+title: "Iceberg compaction"
+sidebarTitle: Compaction
+description: "Learn how RisingWave supports Iceberg compaction for sinks and table engines."
+---
+
+When RisingWave streams data into Iceberg, the process can generate many small data files and delete files. These files accumulate over time, increasing storage overhead and slowing down query performance.
+
+## Periodic compaction
+
+Iceberg compaction for sinks and table engines periodically merges small data files and delete files into larger, optimized data files. These operations run in the background at user-defined intervals, ensuring efficient storage management with minimal disruption.
+
+To configure Iceberg compaction when creating a sink or table, specify the following parameters in the `WITH` clause:
+
+| Parameter                  | Description                                                                 |
+|:---------------------------|:----------------------------------------------------------------------------|
+| `enable_compaction`        | Whether to enable Iceberg compaction (`true`/`false`).                       |
+| `compaction_interval_sec`  | Interval (in seconds) between two compaction runs. Defaults to `3600` seconds. |
+
+For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg table engine](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
+
+## Manual compaction
+
+In addition to periodic background compaction, you can also trigger compaction manually.  
+
+By running the [`VACUUM FULL`](/sql/commands/sql-vacuum) command, RisingWave will compact small files and simultaneously expire old snapshots. This gives you finer control over storage cleanup and is useful when you want to immediately reduce storage overhead or reset snapshot history.
+
+
+

--- a/iceberg/compaction.mdx
+++ b/iceberg/compaction.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Iceberg compaction"
 sidebarTitle: Compaction
-description: "Learn how RisingWave supports Iceberg compaction for sinks and table engines."
+description: "Learn how RisingWave supports Iceberg compaction for sinks and engine tables."
 ---
 
 When RisingWave streams data into Iceberg, the process can generate many small data files and delete files. These files accumulate over time, increasing storage overhead and slowing down query performance.
 
 ## Periodic compaction
 
-Iceberg compaction for sinks and table engines periodically merges small data files and delete files into larger, optimized data files. These operations run in the background at user-defined intervals, ensuring efficient storage management with minimal disruption.
+Iceberg compaction for sinks and engine tables periodically merges small data files and delete files into larger, optimized data files. These operations run in the background at user-defined intervals, ensuring efficient storage management with minimal disruption.
 
 To configure Iceberg compaction when creating a sink or table, specify the following parameters in the `WITH` clause:
 
@@ -17,7 +17,7 @@ To configure Iceberg compaction when creating a sink or table, specify the follo
 | `enable_compaction`        | Whether to enable Iceberg compaction (`true`/`false`).                       |
 | `compaction_interval_sec`  | Interval (in seconds) between two compaction runs. Defaults to `3600` seconds. |
 
-For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg table engine](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
+For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg engine table](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
 
 ## Manual compaction
 

--- a/iceberg/create-manage-native-iceberg-tables.mdx
+++ b/iceberg/create-manage-native-iceberg-tables.mdx
@@ -293,6 +293,10 @@ To configure Iceberg compaction for a native Iceberg table, specify the followin
 | `enable_compaction`         | Whether to enable Iceberg compaction (`true`/`false`).                      |
 | `compaction_interval_sec`   | Interval (in seconds) between two compaction runs. Defaults to 3600 seconds.                           |
 | `enable_snapshot_expiration`| Whether to enable snapshot expiration. By default, it removes snapshots older than 5 days. |
+| `snapshot_expiration_expire_older_than` | The timestamp (in milliseconds) to expire snapshots older than this. |
+| `snapshot_expiration_retain_last` | The number of snapshots to retain. |
+| `snapshot_expiration_clear_expired_files` | Whether to delete expired data files. Default is `true`. |
+| `snapshot_expiration_clear_expired_meta_data` | Whether to delete expired metadata files. Default is `true`. |
 
 ```sql Example
 CREATE TABLE t (
@@ -301,7 +305,11 @@ CREATE TABLE t (
 ) WITH (
     enable_compaction = true, 
     compaction_interval_sec = 3600, 
-    enable_snapshot_expiration = true
+    enable_snapshot_expiration = true,
+    snapshot_expiration_expire_older_than = 604800000,
+    snapshot_expiration_retain_last = 5,
+    snapshot_expiration_clear_expired_files = true,
+    snapshot_expiration_clear_expired_meta_data = true
 ) ENGINE = iceberg;
 ```
 

--- a/iceberg/create-manage-native-iceberg-tables.mdx
+++ b/iceberg/create-manage-native-iceberg-tables.mdx
@@ -293,10 +293,11 @@ To configure Iceberg compaction for a native Iceberg table, specify the followin
 | `enable_compaction`         | Whether to enable Iceberg compaction (`true`/`false`).                      |
 | `compaction_interval_sec`   | Interval (in seconds) between two compaction runs. Defaults to 3600 seconds.                           |
 | `enable_snapshot_expiration`| Whether to enable snapshot expiration. By default, it removes snapshots older than 5 days. |
-| `snapshot_expiration_expire_older_than` | The timestamp (in milliseconds) to expire snapshots older than this. |
+| `snapshot_expiration_max_age_millis` | The maximum age (in milliseconds) for snapshots before they expire. For example, if set to 3600000, snapshots older than 1 hour will be expired. If you want to keep only the latest snapshot, set `snapshot_expiration_max_age_millis = 0`. |
 | `snapshot_expiration_retain_last` | The number of snapshots to retain. |
 | `snapshot_expiration_clear_expired_files` | Whether to delete expired data files. Default is `true`. |
 | `snapshot_expiration_clear_expired_meta_data` | Whether to delete expired metadata files. Default is `true`. |
+| `max_snapshots_num_before_compaction` | The maximum number of snapshots allowed since the last rewrite operation. If set, sink will check snapshot count and wait if exceeded. |
 
 ```sql Example
 CREATE TABLE t (
@@ -306,7 +307,7 @@ CREATE TABLE t (
     enable_compaction = true, 
     compaction_interval_sec = 3600, 
     enable_snapshot_expiration = true,
-    snapshot_expiration_expire_older_than = 604800000,
+    snapshot_expiration_max_age_millis = 604800000,
     snapshot_expiration_retain_last = 5,
     snapshot_expiration_clear_expired_files = true,
     snapshot_expiration_clear_expired_meta_data = true

--- a/iceberg/deliver-to-iceberg.mdx
+++ b/iceberg/deliver-to-iceberg.mdx
@@ -230,10 +230,11 @@ To configure Iceberg compaction when creating a sink, specify the following para
 | `enable_compaction`        | Whether to enable Iceberg compaction (`true`/`false`).                       |
 | `compaction_interval_sec`  | Interval (in seconds) between two compaction runs. Defaults to `3600` seconds. |
 | `enable_snapshot_expiration` | Whether to enable snapshot expiration. By default, it removes snapshots older than 5 days. |
-| `snapshot_expiration_expire_older_than` | The timestamp (in milliseconds) to expire snapshots older than this. |
+| `snapshot_expiration_max_age_millis` | The maximum age (in milliseconds) for snapshots before they expire. For example, if set to 3600000, snapshots older than 1 hour will be expired. If you want to keep only the latest snapshot, set `snapshot_expiration_max_age_millis = 0`. |
 | `snapshot_expiration_retain_last` | The number of snapshots to retain. |
 | `snapshot_expiration_clear_expired_files` | Whether to delete expired data files. Default is `true`. |
 | `snapshot_expiration_clear_expired_meta_data` | Whether to delete expired metadata files. Default is `true`. |
+| `max_snapshots_num_before_compaction` | The maximum number of snapshots allowed since the last rewrite operation. If set, sink will check snapshot count and wait if exceeded. |
 
 ```sql Example
 CREATE SINK sink_demo_rest FROM t
@@ -255,7 +256,7 @@ WITH (
     enable_compaction=true, 
     compaction_interval_sec=3600, 
     enable_snapshot_expiration=true,
-    snapshot_expiration_expire_older_than = 604800000,
+    snapshot_expiration_max_age_millis = 604800000,
     snapshot_expiration_retain_last = 5,
     snapshot_expiration_clear_expired_files = true,
     snapshot_expiration_clear_expired_meta_data = true
@@ -268,8 +269,8 @@ WITH (
 Currently, please contact us via [RisingWave Slack workspace](https://www.risingwave.com/slack) to allocate the necessary resources. We are working on a self-service feature that will let you allocate Iceberg compactors directly from the cloud portal.
 </Warning>
 
-RisingWave also supports compaction for Iceberg table engine. For details, see [
-Compaction for Iceberg table engine](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
+RisingWave also supports compaction for Iceberg engine table. For details, see [
+Compaction for Iceberg engine table](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
 
 ## Use with different storage backends
 

--- a/iceberg/deliver-to-iceberg.mdx
+++ b/iceberg/deliver-to-iceberg.mdx
@@ -230,6 +230,10 @@ To configure Iceberg compaction when creating a sink, specify the following para
 | `enable_compaction`        | Whether to enable Iceberg compaction (`true`/`false`).                       |
 | `compaction_interval_sec`  | Interval (in seconds) between two compaction runs. Defaults to `3600` seconds. |
 | `enable_snapshot_expiration` | Whether to enable snapshot expiration. By default, it removes snapshots older than 5 days. |
+| `snapshot_expiration_expire_older_than` | The timestamp (in milliseconds) to expire snapshots older than this. |
+| `snapshot_expiration_retain_last` | The number of snapshots to retain. |
+| `snapshot_expiration_clear_expired_files` | Whether to delete expired data files. Default is `true`. |
+| `snapshot_expiration_clear_expired_meta_data` | Whether to delete expired metadata files. Default is `true`. |
 
 ```sql Example
 CREATE SINK sink_demo_rest FROM t
@@ -247,10 +251,14 @@ WITH (
     warehouse.path = 'warehouse',
     database.name = 'ns',
     table.name = 't1',
-    -- the following configurations are about iceberg compaction
+    -- the following configurations are about Iceberg compaction
     enable_compaction=true, 
     compaction_interval_sec=3600, 
-    enable_snapshot_expiration=true
+    enable_snapshot_expiration=true,
+    snapshot_expiration_expire_older_than = 604800000,
+    snapshot_expiration_retain_last = 5,
+    snapshot_expiration_clear_expired_files = true,
+    snapshot_expiration_clear_expired_meta_data = true
 );
 ```
 

--- a/iceberg/integrate-databricks-glue.mdx
+++ b/iceberg/integrate-databricks-glue.mdx
@@ -66,7 +66,7 @@ WITH (
 ```
 
 <Note>
-For `upsert` type, since Databricks doesn’t support reading position delete and equality delete files, please use Copy-on-Write mode `write_mode = 'copy-on-write'` and enable the Iceberg compaction as well. The `compaction_interval_sec` determines the freshness of the Iceberg table, since Copy-on-Write mode relies on the Iceberg compaction.
+For `upsert` type, since Databricks doesn’t support reading position delete and equality delete files, please use [Copy-on-Write mode](/iceberg/write-mode-copy-on-write) `write_mode = 'copy-on-write'` and enable the Iceberg compaction as well. The `compaction_interval_sec` determines the freshness of the Iceberg table, since Copy-on-Write mode relies on the Iceberg compaction.
 </Note>
 
 ## Query Iceberg table in Databricks

--- a/iceberg/integrate-snowflake.mdx
+++ b/iceberg/integrate-snowflake.mdx
@@ -70,7 +70,7 @@ WITH (
 ```
 
 <Note>
-For `upsert` type, since Snowflake doesn’t support reading equality delete files, please use Copy-on-Write mode `write_mode = 'copy-on-write'` and enable the Iceberg compaction as well. The `compaction_interval_sec` determines the freshness of the Iceberg table, since Copy-on-Write mode relies on the Iceberg compaction.
+For `upsert` type, since Snowflake doesn’t support reading equality delete files, please use [Copy-on-Write mode](/iceberg/write-mode-copy-on-write) `write_mode = 'copy-on-write'` and enable the Iceberg compaction as well. The `compaction_interval_sec` determines the freshness of the Iceberg table, since Copy-on-Write mode relies on the Iceberg compaction.
 </Note>
 
 ## Configure Snowflake catalog integration

--- a/iceberg/snapshot-expiration.mdx
+++ b/iceberg/snapshot-expiration.mdx
@@ -1,0 +1,28 @@
+---
+title: "Iceberg snapshot expiration"
+sidebarTitle: Snapshot expiration
+description: "Learn how RisingWave supports Iceberg snapshot expiration for sinks and table engines."
+---
+
+When RisingWave streams data into Iceberg, it continuously creates snapshots that capture the state of a table or a sink at a given point in time. Over time, these snapshots accumulate and consume storage. Regularly expiring old snapshots helps keep storage usage under control and improves query performance.
+
+## Periodic expiration
+
+RisingWave supports automatic snapshot expiration for sinks and table engines. At user-defined intervals, the system evaluates existing snapshots and removes those that are older than the configured threshold or exceed the retention count. You can also configure whether to clean up expired data and metadata files.
+
+To enable snapshot expiration, specify the following parameters in the `WITH` clause when creating a sink or table:
+
+| Parameter                                      | Description                                                                 |
+|:-----------------------------------------------|:----------------------------------------------------------------------------|
+| `snapshot_expiration_expire_older_than`        | The timestamp (in milliseconds) to expire snapshots older than this.         |
+| `snapshot_expiration_retain_last`              | The number of snapshots to retain.                                           |
+| `snapshot_expiration_clear_expired_files`      | Whether to delete expired data files. Default is `true`.                     |
+| `snapshot_expiration_clear_expired_meta_data`  | Whether to delete expired metadata files. Default is `true`.                 |
+
+For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg table engine](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
+
+## Manual expiration
+
+In addition to periodic background expiration, you can also expire snapshots manually.  
+
+By running the [`VACUUM FULL`](/sql/commands/sql-vacuum) command, RisingWave will expire old snapshots on demand. This is useful when you want to immediately reclaim storage or reset snapshot history.

--- a/iceberg/snapshot-expiration.mdx
+++ b/iceberg/snapshot-expiration.mdx
@@ -1,25 +1,27 @@
 ---
 title: "Iceberg snapshot expiration"
 sidebarTitle: Snapshot expiration
-description: "Learn how RisingWave supports Iceberg snapshot expiration for sinks and table engines."
+description: "Learn how RisingWave supports Iceberg snapshot expiration for sinks and engine tables."
 ---
 
 When RisingWave streams data into Iceberg, it continuously creates snapshots that capture the state of a table or a sink at a given point in time. Over time, these snapshots accumulate and consume storage. Regularly expiring old snapshots helps keep storage usage under control and improves query performance.
 
 ## Periodic expiration
 
-RisingWave supports automatic snapshot expiration for sinks and table engines. At user-defined intervals, the system evaluates existing snapshots and removes those that are older than the configured threshold or exceed the retention count. You can also configure whether to clean up expired data and metadata files.
+RisingWave supports automatic snapshot expiration for sinks and engine tables. At user-defined intervals, the system evaluates existing snapshots and removes those that are older than the configured threshold or exceed the retention count. You can also configure whether to clean up expired data and metadata files.
 
 To enable snapshot expiration, specify the following parameters in the `WITH` clause when creating a sink or table:
 
 | Parameter                                      | Description                                                                 |
 |:-----------------------------------------------|:----------------------------------------------------------------------------|
-| `snapshot_expiration_expire_older_than`        | The timestamp (in milliseconds) to expire snapshots older than this.         |
-| `snapshot_expiration_retain_last`              | The number of snapshots to retain.                                           |
-| `snapshot_expiration_clear_expired_files`      | Whether to delete expired data files. Default is `true`.                     |
-| `snapshot_expiration_clear_expired_meta_data`  | Whether to delete expired metadata files. Default is `true`.                 |
+| `enable_snapshot_expiration` | Whether to enable snapshot expiration. By default, it removes snapshots older than 5 days. |
+| `snapshot_expiration_max_age_millis` | The maximum age (in milliseconds) for snapshots before they expire. For example, if set to 3600000, snapshots older than 1 hour will be expired. If you want to keep only the latest snapshot, set `snapshot_expiration_max_age_millis = 0`. |
+| `snapshot_expiration_retain_last` | The number of snapshots to retain. |
+| `snapshot_expiration_clear_expired_files` | Whether to delete expired data files. Default is `true`. |
+| `snapshot_expiration_clear_expired_meta_data` | Whether to delete expired metadata files. Default is `true`. |
+| `max_snapshots_num_before_compaction` | The maximum number of snapshots allowed since the last rewrite operation. If set, sink will check snapshot count and wait if exceeded. |
 
-For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg table engine](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
+For detailed syntax, parameters, and configuration details, see [Compaction for Iceberg sink](/iceberg/deliver-to-iceberg#compaction-for-iceberg-sink) and [Compaction for Iceberg engine table](/iceberg/create-manage-native-iceberg-tables#compaction-for-native-iceberg-tables).
 
 ## Manual expiration
 

--- a/iceberg/write-mode-copy-on-write.mdx
+++ b/iceberg/write-mode-copy-on-write.mdx
@@ -18,13 +18,36 @@ The trade-off is higher write amplification and potential latency during compact
 
 To use Copy-on-Write mode, set the parameter `write_mode = 'copy-on-write'` when creating your Iceberg table or sink.
 
-```sql
+```sql Create an Iceberg table
 CREATE TABLE t_copy_on_write (
     a INT PRIMARY KEY,
     b INT
 ) WITH (
-    commit_checkpoint_interval = 1,
-    compaction_interval_sec = 10,
+    commit_checkpoint_interval = 10,
+    compaction_interval_sec = 30,
     write_mode = 'copy-on-write'
 ) ENGINE = iceberg;
+```
+
+```sql Create an Iceberg sink
+CREATE SINK rest_sink FROM my_data
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    warehouse.path = 's3://my-bucket/warehouse',
+    database.name = 'my_database',
+    table.name = 'my_table',
+    catalog.type = 'rest',
+    catalog.uri = 'http://rest-catalog:8181',
+    catalog.credential = 'username:password',
+    s3.access.key = 'your-access-key',
+    s3.secret.key = 'your-secret-key',
+    enable_compaction = true,
+    write_mode = 'copy-on-write',
+    commit_checkpoint_interval = 10,
+    compaction_interval_sec = 30,
+    enable_snapshot_expiration = true,
+    snapshot_expiration_max_age_millis=0
+);
 ```

--- a/iceberg/write-mode-copy-on-write.mdx
+++ b/iceberg/write-mode-copy-on-write.mdx
@@ -1,0 +1,30 @@
+---
+title: "Copy-on-Write mode"
+sidebarTitle: Copy-on-Write mode
+description: "Learn how RisingWave uses Copy-on-Write mode for Iceberg tables and sinks."
+---
+
+RisingWave supports copy-on-write (CoW) mode for Iceberg tables and sinks. This is designed to ensure that external consumers always see a clean, delete-free snapshot of the data.
+
+Iceberg CoW mode uses two branches to separate ingestion from external queries. The **ingestion-branch** handles continuous writes, including data files and delete files, while the **main-branch** provides a clean, delete-free view for downstream applications.
+
+## Scenario
+
+Instead of leaving delete files for readers to merge in [MoR mode](/iceberg/write-mode-merge-on-read), RisingWave periodically rewrites data files to absorb the deletes. This approach is ideal for workloads with frequent upserts where downstream systems require a stable and consistent view.
+
+The trade-off is higher write amplification and potential latency during compaction.
+
+## Example
+
+To use Copy-on-Write mode, set the parameter `write_mode = 'copy-on-write'` when creating your Iceberg table or sink.
+
+```sql
+CREATE TABLE t_cow (
+    a INT PRIMARY KEY,
+    b INT
+) WITH (
+    commit_checkpoint_interval = 1,
+    compaction_interval_sec = 10,
+    write_mode = 'copy-on-write'
+) ENGINE = iceberg;
+```

--- a/iceberg/write-mode-copy-on-write.mdx
+++ b/iceberg/write-mode-copy-on-write.mdx
@@ -19,7 +19,7 @@ The trade-off is higher write amplification and potential latency during compact
 To use Copy-on-Write mode, set the parameter `write_mode = 'copy-on-write'` when creating your Iceberg table or sink.
 
 ```sql
-CREATE TABLE t_cow (
+CREATE TABLE t_copy_on_write (
     a INT PRIMARY KEY,
     b INT
 ) WITH (

--- a/iceberg/write-mode-merge-on-read.mdx
+++ b/iceberg/write-mode-merge-on-read.mdx
@@ -15,7 +15,7 @@ This mode is particularly efficient for continuous ingestion because it avoids r
 To use Merge-on-Read mode, set the parameter `write_mode = 'merge-on-read'` when creating your Iceberg table or sink.
 
 ```
-CREATE TABLE t_mor (
+CREATE TABLE t_merge_on_read (
     id INT PRIMARY KEY,
     value STRING
 ) WITH (

--- a/iceberg/write-mode-merge-on-read.mdx
+++ b/iceberg/write-mode-merge-on-read.mdx
@@ -1,0 +1,24 @@
+---
+title: "Merge-on-Read mode"
+sidebarTitle: Merge-on-Read mode
+description: "Learn how RisingWave uses Merge-on-Read mode for Iceberg tables and sinks."
+---
+
+RisingWave supports merge-on-read (MoR) mode as the default write mode for Iceberg tables and sinks. In this mode, both data files and delete files are written directly into the tables and sinks. When external queries are executed, the engine reads these files and merges them to produce the latest view of the data.
+
+## Scenario
+
+This mode is particularly efficient for continuous ingestion because it avoids rewriting data files for every update or delete. However, queries must apply delete files at read time, which can add overhead. Merge-on-read is ideal when downstream systems, such as query engines, natively support Iceberg deletes and can efficiently reconstruct the latest data.
+
+## Example
+
+To use Merge-on-Read mode, set the parameter `write_mode = 'merge-on-read'` when creating your Iceberg table or sink.
+
+```
+CREATE TABLE t_mor (
+    id INT PRIMARY KEY,
+    value STRING
+) WITH (
+    write_mode = 'merge-on-read'
+) ENGINE = iceberg;
+```

--- a/iceberg/write-mode-merge-on-read.mdx
+++ b/iceberg/write-mode-merge-on-read.mdx
@@ -14,11 +14,34 @@ This mode is particularly efficient for continuous ingestion because it avoids r
 
 To use Merge-on-Read mode, set the parameter `write_mode = 'merge-on-read'` when creating your Iceberg table or sink.
 
-```
+```sql Create an Iceberg engine table
 CREATE TABLE t_merge_on_read (
     id INT PRIMARY KEY,
     value STRING
 ) WITH (
     write_mode = 'merge-on-read'
 ) ENGINE = iceberg;
+```
+
+```sql Create an Iceberg sink
+CREATE SINK rest_sink FROM my_data
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    warehouse.path = 's3://my-bucket/warehouse',
+    database.name = 'my_database',
+    table.name = 'my_table',
+    catalog.type = 'rest',
+    catalog.uri = 'http://rest-catalog:8181',
+    catalog.credential = 'username:password',
+    s3.access.key = 'your-access-key',
+    s3.secret.key = 'your-secret-key',
+    enable_compaction = true,
+    write_mode = 'merge-on-read',
+    commit_checkpoint_interval = 10,
+    compaction_interval_sec = 30,
+    enable_snapshot_expiration = true,
+    snapshot_expiration_max_age_millis=0
+);
 ```

--- a/mint.json
+++ b/mint.json
@@ -245,6 +245,13 @@
           ]
         },
         {
+          "group": "Write modes",
+          "pages": [
+            "iceberg/write-mode-merge-on-read",
+            "iceberg/write-mode-copy-on-write"
+          ]
+        },
+        {
           "group": "Maintenance",
           "pages": [
             "iceberg/compaction",

--- a/mint.json
+++ b/mint.json
@@ -243,6 +243,13 @@
             "iceberg/catalogs",
             "iceberg/object-storage"
           ]
+        },
+        {
+          "group": "Maintenance",
+          "pages": [
+            "iceberg/compaction",
+            "iceberg/snapshot-expiration"
+          ]
         }
       ]
     },
@@ -589,7 +596,8 @@
                 "sql/commands/sql-show-tables",
                 "sql/commands/sql-show-views",
                 "sql/commands/sql-start-transaction",
-                "sql/commands/sql-update"
+                "sql/commands/sql-update",
+                "sql/commands/sql-vacuum"
               ]
             },
             {

--- a/sql/commands/overview.mdx
+++ b/sql/commands/overview.mdx
@@ -270,6 +270,9 @@ sidebarTitle: Overview
   <Card title="UPDATE" icon="pen" iconType="solid" href="/sql/commands/sql-update">
     Modify existing rows in a table.
   </Card>
+  <Card title="VACUUM" icon="eraser" iconType="solid" href="/sql/commands/sql-vacuum">
+    Enable manual compaction and snapshot expiration.
+  </Card>
 </CardGroup>
 
 

--- a/sql/commands/sql-vacuum.mdx
+++ b/sql/commands/sql-vacuum.mdx
@@ -3,7 +3,7 @@ title: "VACUUM"
 description: "Introduce VACUUM syntax for Iceberg tables and sinks to enable manual compaction and snapshot expiration in RisingWave."
 ---
 
-RisingWave supports `VACUUM` syntax for Iceberg table engine and Iceberg sink. This allows you to manage storage, reclaim disk space, and optimize performance for Iceberg data within RisingWave.
+RisingWave supports `VACUUM` syntax for Iceberg engine table and Iceberg sink. This allows you to manage storage, reclaim disk space, and optimize performance for Iceberg data within RisingWave.
 
 ## Syntax
 
@@ -20,7 +20,7 @@ VACUUM [FULL] schema_name.object_name;
 | Parameter             | Description     |
 | :-------------------- | :-------------- |
 | FULL | Optional. If specified, compacts the table and expires snapshots; otherwise, only snapshots are expired. |
-| object_name | Can be an Iceberg table engine or an Iceberg sink. |
+| object_name | Can be an Iceberg engine table or an Iceberg sink. |
 
 
 ## Example

--- a/sql/commands/sql-vacuum.mdx
+++ b/sql/commands/sql-vacuum.mdx
@@ -1,0 +1,49 @@
+---
+title: "VACUUM"
+description: "Introduce VACUUM syntax for Iceberg tables and sinks to enable manual compaction and snapshot expiration in RisingWave."
+---
+
+RisingWave supports `VACUUM` syntax for Iceberg table engine and Iceberg sink. This allows you to manage storage, reclaim disk space, and optimize performance for Iceberg data within RisingWave.
+
+## Syntax
+
+```sql
+VACUUM [FULL] schema_name.object_name;
+```
+
+- `VACUUM`: Manually **expires** old snapshots on the specified Iceberg table/sink, freeing up space used by outdated versions.
+- `VACUUM FULL`: **Compacts** the specified Iceberg table/sink (rewrites the table to reclaim space), then **expires** outdated snapshots. This operation takes longer and requires extra disk space, as a new copy is written before the old copy is released.
+
+
+## Parameters
+
+| Parameter             | Description     |
+| :-------------------- | :-------------- |
+| FULL | Optional. If specified, compacts the table and expires snapshots; otherwise, only snapshots are expired. |
+| object_name | Can be an Iceberg table engine or an Iceberg sink. |
+
+
+## Example
+
+```sql
+-- Insert and update data
+insert into t_vacuum_test values(1, 'alice', 100), (2, 'bob', 200), (3, 'charlie', 300);
+FLUSH;
+-- sleep 5s
+
+-- Check data
+select * from t_vacuum_test;
+
+-- More inserts/updates
+insert into t_vacuum_test values(4, 'david', 400), (5, 'eve', 500);
+FLUSH;
+-- sleep 5s
+update t_vacuum_test set v1 = 150 where id = 1;
+FLUSH;
+-- sleep 5s
+
+-- Run VACUUM and verify
+VACUUM t_vacuum_test;
+
+VACUUM FULL t_vacuum_test;
+```


### PR DESCRIPTION
## Description

Click to see preview, let me know if any comments, thanks!

[Maintenance](https://risingwavelabs-wyx-iceberg-maintenance.mintlify.app/iceberg/compaction)
- Compaction
- Snapshot expiration

[Write mode](https://risingwavelabs-wyx-iceberg-maintenance.mintlify.app/iceberg/write-mode-merge-on-read)
- merge-on-read (default)
- copy-on-write

[VACUUM syntax](https://risingwavelabs-wyx-iceberg-maintenance.mintlify.app/sql/commands/sql-vacuum)

## Related code PR

Vacuum: https://github.com/risingwavelabs/risingwave/pull/22942
CoW mode: https://github.com/risingwavelabs/risingwave/pull/22713
Snapshot expiration: https://github.com/risingwavelabs/risingwave/pull/22947

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/608
Fix https://github.com/risingwavelabs/risingwave-docs/issues/630
Fix https://github.com/risingwavelabs/risingwave-docs/issues/666

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
