### PR TITLE
Document: add auto schema change for es, redshift, snowflake

### DIFF
--- a/get-started/premium-features.mdx
+++ b/get-started/premium-features.mdx
@@ -50,9 +50,9 @@ The [**Elastic disk cache**](/get-started/disk-cache) feature harnesses modern h
 
 - [Auto schema change for PostgreSQL CDC](/ingestion/sources/postgresql/pg-cdc#auto-schema-change)
 - [Auto schema change for MySQL CDC](/ingestion/sources/mysql/mysql-cdc#auto-schema-change)
-- [Auto schema change for Elasticsearch](/integrations/destinations/elasticsearch#auto-schema-change)
-- [Auto schema change for Snowflake](/integrations/destinations/snowflake-v2#auto-schema-change)
-- [Auto schema change for Redshift](/integrations/destinations/redshift#auto-schema-change)
+- [Auto schema change for Elasticsearch Sink](/integrations/destinations/elasticsearch#auto-schema-change)
+- [Auto schema change for Snowflake Sink](/integrations/destinations/snowflake-v2#auto-schema-change)
+- [Auto schema change for Redshift Sink](/integrations/destinations/redshift#auto-schema-change)
 - [AWS Glue Schema Registry for Kafka Source](/ingestion/sources/kafka-config#use-aws-glue-schema-registry) and [Kafka Sink](/integrations/destinations/apache-kafka#use-aws-glue-schema-registry)
 
 ### Connectors

--- a/get-started/premium-features.mdx
+++ b/get-started/premium-features.mdx
@@ -48,8 +48,11 @@ The [**Elastic disk cache**](/get-started/disk-cache) feature harnesses modern h
 
 ### Schema management
 
-- [Automatic schema changes for PostgreSQL CDC](/ingestion/sources/postgresql/pg-cdc#automatic-schema-changes)
-- [Automatic schema changes for MySQL CDC](/ingestion/sources/mysql/mysql-cdc#automatic-schema-changes)
+- [Auto schema change for PostgreSQL CDC](/ingestion/sources/postgresql/pg-cdc#auto-schema-change)
+- [Auto schema change for MySQL CDC](/ingestion/sources/mysql/mysql-cdc#auto-schema-change)
+- [Auto schema change for Elasticsearch](/integrations/destinations/elasticsearch#auto-schema-change)
+- [Auto schema change for Snowflake](/integrations/destinations/snowflake-v2#auto-schema-change)
+- [Auto schema change for Redshift](/integrations/destinations/redshift#auto-schema-change)
 - [AWS Glue Schema Registry for Kafka Source](/ingestion/sources/kafka-config#use-aws-glue-schema-registry) and [Kafka Sink](/integrations/destinations/apache-kafka#use-aws-glue-schema-registry)
 
 ### Connectors

--- a/ingestion/sources/mysql/mysql-cdc.mdx
+++ b/ingestion/sources/mysql/mysql-cdc.mdx
@@ -311,7 +311,7 @@ And this it the output of `DESCRIBE supplier;`
 
 ```
 
-## Automatic schema changes
+## Auto schema change
 
 <Tip>
 **PREMIUM FEATURE**

--- a/ingestion/sources/postgresql/pg-cdc.mdx
+++ b/ingestion/sources/postgresql/pg-cdc.mdx
@@ -370,7 +370,7 @@ Instead of defining columns individually, you can use `*` when creating a table 
 ```sql
 CREATE TABLE <table_name> (*) FROM <source_name> TABLE '<schema_name>.<table_name>';
 ```
-### Automatic schema changes
+### Auto schema change
 
 <Tip>
 **PREMIUM FEATURE**

--- a/integrations/destinations/elasticsearch.mdx
+++ b/integrations/destinations/elasticsearch.mdx
@@ -58,10 +58,29 @@ WITH (
 | username             | **Optional**. elastic user name for accessing the Elasticsearch endpoint. It must be used with password.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | password             | **Optional**. Password for accessing the Elasticsearch endpoint. It must be used with username.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | delimiter            | **Optional**. Delimiter for Elasticsearch ID when the sink's primary key has multiple columns.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| auto_schema_change             | Enable automatic schema change for upsert sink; adds new columns to target table if needed |
 
 For versions under 8.x, there was once a parameter `type`. In Elasticsearch 6.x, users could directly set the type, but starting from 7.x, it is set to not recommended and the default value is unified to `_doc`. In version 8.x, the type has been completely removed. See [Elasticsearch's official documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html) for more details.
 
 So, if you are using Elasticsearch 7.x, we set it to the official's recommended value, which is `_doc`. If you are using Elasticsearch 8.x, this parameter has been removed by the Elasticsearch official, so no setting is required.
+
+## Auto schema change
+
+<Tip>
+**PREMIUM FEATURE**
+
+This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
+</Tip>
+
+Elasticsearch sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+
+Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+
+To enable it, set the following option when creating the sink:
+
+```sql
+auto_schema_change = true
+```
 
 
 ## Primary keys and Elasticsearch IDs

--- a/integrations/destinations/elasticsearch.mdx
+++ b/integrations/destinations/elasticsearch.mdx
@@ -72,9 +72,9 @@ So, if you are using Elasticsearch 7.x, we set it to the official's recommended 
 This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
 </Tip>
 
-Elasticsearch sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+Elasticsearch sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
 
-Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+Once auto schema change is enabled, if you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
 
 To enable it, set the following option when creating the sink:
 

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -52,9 +52,21 @@ These options only need to be set when `with_s3 = true`:
 
 ## Auto schema change
 
-Redshift supports sink auto schema change when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`. With auto schema change enabled in the Redshift sink, RisingWave can automatically evolve the schema of your Redshift table. When new columns are detected in the source data, RisingWave will add those columns to the Redshift table before ingesting new records. This automation simplifies data pipeline maintenance and ensures that your Redshift table structure always reflects the latest upstream schema.
+<Tip>
+**PREMIUM FEATURE**
 
-To enable it, set `auto_schema_change` to true, and RisingWave will automatically add new columns to the target table.
+This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
+</Tip>
+
+Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+
+Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+
+To enable it, set the following option when creating the sink:
+
+```sql
+auto_schema_change = true
+```
 
 ## Configure RisingWave to write to S3
 

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -58,9 +58,9 @@ These options only need to be set when `with_s3 = true`:
 This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
 </Tip>
 
-Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
 
-Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+Once auto schema change is enabled, if you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
 
 To enable it, set the following option when creating the sink:
 

--- a/integrations/destinations/snowflake-v2.mdx
+++ b/integrations/destinations/snowflake-v2.mdx
@@ -62,9 +62,9 @@ These options only need to be set when `with_s3 = true`:
 This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
 </Tip>
 
-Snowflake v2 sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+Snowflake v2 sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
 
-Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+Once auto schema change is enabled, if you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
 
 To enable it, set the following option when creating the sink:
 

--- a/integrations/destinations/snowflake-v2.mdx
+++ b/integrations/destinations/snowflake-v2.mdx
@@ -56,14 +56,21 @@ These options only need to be set when `with_s3 = true`:
 
 ## Auto schema change
 
-Snowflake v2 supports sink auto schema change when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`. When enabled, RisingWave will automatically alter the target table to add new columns from the upstream data source.
+<Tip>
+**PREMIUM FEATURE**
 
-To enable it:
+This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
+</Tip>
+
+Snowflake v2 sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is `false`.
+
+Once auto schema change is enabled, if you alter the schema of the source table (e.g., add, drop, or modify columns), the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
+
+To enable it, set the following option when creating the sink:
 
 ```sql
 auto_schema_change = true
 ```
-This ensures your Snowflake table stays in sync with upstream schema changes with minimal manual intervention.
 
 ## Configure RisingWave to write to S3
 


### PR DESCRIPTION
## Description

Click below to see preview.
Support auto schema change for [Elasticsearch](https://risingwavelabs-wyx-add-auto-schema-changes.mintlify.app/integrations/destinations/elasticsearch#auto-schema-change), [Redshift](https://risingwavelabs-wyx-add-auto-schema-changes.mintlify.app/integrations/destinations/redshift#auto-schema-change), [Snowflake](https://risingwavelabs-wyx-add-auto-schema-changes.mintlify.app/integrations/destinations/snowflake-v2#auto-schema-change) and unify the name. 

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/22611

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/659

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
