### PR TITLE
Fix: clarify webhook port

### DIFF
--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -6,8 +6,7 @@ description: Describes how to ingest data from webhook to RisingWave.
 
 A webhook is a mechanism that enables real-time data transfer between applications by sending immediate notifications when specific events occur. Instead of continuously polling for updates, applications can receive data automatically, making it an efficient way to integrate with third-party services.
 
-RisingWave can serve as a webhook destination, directly accepting HTTP requests from external services and storing the incoming data in its tables. When a webhook is triggered, RisingWave processes and ingests the data in real-time.
-
+RisingWave can serve as a webhook destination, directly accepting HTTP requests from external services and storing the incoming data in its tables. By default, the frontend node listens for webhook events on port `4560`. You can reconfigure this depending on how your cluster is deployed. When a webhook is triggered, RisingWave processes and ingests the data in real-time.
 
 This direct integration eliminates the need for an intermediary message broker like Kafka. Instead of setting up and maintaining an extra Kafka cluster, you can directly send data to RisingWave to process it in real-time, which enables efficient data ingestion and stream processing without extra infrastructure.
 


### PR DESCRIPTION
## Description

Fix https://github.com/risingwavelabs/risingwave-docs/pull/729

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
