### PR TITLE
Fix: add RisingWave Console setup section to Kubernetes and Helm pages

### DIFF
--- a/deploy/risingwave-k8s-helm.mdx
+++ b/deploy/risingwave-k8s-helm.mdx
@@ -138,3 +138,9 @@ compactorComponent:
 
 ```
 Please note that increasing the CPU resource will not automatically increase the parallelism of existing materialized views. When scaling up (adding more CPU cores) a Streaming Node, you should perform the scaling by following the instructions in [Cluster scaling](/deploy/k8s-cluster-scaling).
+
+## Set up RisingWave Console
+
+After deploying your RisingWave cluster with Helm, we recommend setting up RisingWave Console. The Console provides a web interface for managing and monitoring your cluster. It simplifies daily operations and helps you quickly collect and share diagnostic information when contacting RisingWave support team.
+
+For detailed instructions, see [RisingWave Console setup guide](/risingwave-console/introduction).

--- a/deploy/risingwave-kubernetes.mdx
+++ b/deploy/risingwave-kubernetes.mdx
@@ -555,3 +555,9 @@ psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
 </Tabs>
 
 Now you can ingest and transform streaming data. See [Quick start](/get-started/quickstart) for details.
+
+## Set up RisingWave Console
+
+After deploying your RisingWave cluster on Kubernetes, we recommend setting up RisingWave Console. The Console provides a web interface for managing and monitoring your cluster. It simplifies daily operations and helps you quickly collect and share diagnostic information when contacting RisingWave support team.
+
+For detailed instructions, see [RisingWave Console setup guide](/risingwave-console/introduction).


### PR DESCRIPTION
## Description

As title

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/721

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
