### PR TITLE
Cloud: add out-of-memory error to alert playbook

### DIFF
--- a/cloud/alert-playbooks.mdx
+++ b/cloud/alert-playbooks.mdx
@@ -7,6 +7,20 @@ RisingWave Cloud provides detailed alert playbooks to help you quickly diagnose 
 
 This guide is regularly updated to address emerging scenarios.
 
+## Service Health
+
+### Out of memory error
+
+A RisingWave container was terminated due to an Out of Memory (OOM) condition in the project.
+
+**Triggers**
+    - Large backfill operations.
+    - Sudden spikes in workload.
+
+**Resolution**
+
+Scale the node resources. For more information, see [Configure node resources](/cloud/scale-a-project-manually#configure-node-resources).
+
 ## Streaming
 
 ### Barrier pending for too long


### PR DESCRIPTION
## Description

Context: https://risingwave-labs.slack.com/archives/C097PC57P63/p1759999416158089

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
