### PR TITLE
Fix: add how to deploy risingwave webhook listener

### DIFF
--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -69,14 +69,123 @@ RisingWave has been verified to work with the following webhook sources and auth
 |AWS EventBridge| Bearer Token |
 |Rudderstack| Bearer Token |
 
-<Note>While only the above sources have been thoroughly tested, RisingWave can support additional webhook sources and authentication methods. You can integrate other services using similar configurations.</Note>
-
-## See also
-
-Step-by-step guide to help you set up and configure your webhook sources:
+Here are step-by-step guide to help you set up and configure your webhook sources:
 
 - [Ingest from Github webhook](/integrations/sources/github-webhook)
 - [Ingest from Segment webhook](/integrations/sources/segment-webhook)
 - [Ingest from HubSpot webhook](/integrations/sources/hubspot-webhook)
 - [Ingest from Amazon EventBridge webhook](/integrations/sources/eventbridge-webhook)
 - [Ingest from RudderStack webhook](/integrations/sources/rudderstack-webhook)
+
+<Note>While only the above sources have been thoroughly tested, RisingWave can support additional webhook sources and authentication methods. You can integrate other services using similar configurations.</Note>
+
+## Deploy RisingWave webhook listener
+
+Learn how to deploy and test RisingWave's webhook listener using open-source tools such as **Kubernetes Operator** and **Helm Chart**.
+
+### Kubernetes operator
+
+<Info>Make sure risingwave-operator ≥ [v0.12.0](https://github.com/risingwavelabs/risingwave-operator/releases/tag/v0.12.0).</Info>
+
+1. Prepare a YAML manifest of RisingWave with the following field set:
+
+    ```yaml
+    apiVersion: risingwave.risingwavelabs.com/v1alpha1
+    kind: RisingWave
+    metadata:
+      name: risingwave
+    spec:
+      enableWebhookListener: true
+    ```
+
+    You can try with the [base YAML](https://github.com/risingwavelabs/risingwave-operator/blob/main/docs/manifests/stable/persistent/minio/risingwave.yaml). 
+
+2. Apply the YAML to create RisingWave.
+
+**Endpoint (intra-Kubernetes)**
+
+The endpoint depends on the object name and namespace:
+
+```bash
+Example: risingwave-frontend.default.svc.cluster.local:4560
+Format: <service name>.<namespace>.svc.<cluster domain>:4560
+```
+
+### Helm Chart
+
+<Info>Make sure Helm chart ≥ [0.2.38](https://github.com/risingwavelabs/helm-charts/releases/tag/risingwave-0.2.38).</Info>
+
+1. Prepare a YAML values of RisingWave with the following field set:
+
+    ```yaml
+    frontendComponent:
+      webhookListener: true
+    ```
+
+2. Install a Helm release with the values.
+
+    ```bash Example command
+    helm install --set tags.bundle=true,frontendComponent.webhookListener=true risingwave risingwavelabs/risingwave --version 0.2.38
+    ```
+
+**Endpoint (intra-Kubernetes)**
+
+Depending on the release name and namespace:
+
+```bash
+Example: risingwave.default.svc.cluster.local:4560
+Format: <service name>.<namespace>.svc.<cluster domain>:4560
+```
+
+### Test webhook locally (Helm + Local)
+
+To test the webhook locally using Helm, first install a Helm release using the example command provided in [Helm Chart](/integrations/sources/webhook#helm-chart). For local testing, it is recommended to use Orbstack on macOS or cloud testing clusters on other platforms. Once the Helm release is running, follow these steps:
+
+1. Forward ports of the RisingWave to local
+    
+    ```bash
+    kubectl port-forward svc/risingwave 4560,4567
+    ```
+    
+2. Connect with `psql` and create a demo table.
+    
+    ```bash
+    psql -h localhost -p 4567 -d dev -U root
+    dev=> CREATE TABLE wbhtable (
+      data JSONB
+    ) WITH (
+      connector = 'webhook'
+    ) VALIDATE AS secure_compare (
+      headers->>'signature',
+      '1'
+    );
+    CREATE_TABLE
+    ```
+
+3. Send sample data with `curl`
+    
+    ```bash
+    curl -v -X POST http://localhost:4560/webhook/dev/public/wbhtable \
+                  -H "Content-Type: application/json" \
+                  -H "signature: 1" \
+                  -d '{
+            "event": "user.signup",
+            "timestamp": "2025-10-10T08:30:00Z",
+            "data": {
+              "user_id": "12345",
+              "email": "test@example.com",
+              "name": "John Doe"
+            }
+          }'
+    ```
+    
+4. Go back to step 2 and query from the table.
+    
+    ```bash
+    psql -h localhost -p 4567 -d dev -U root
+    dev=> select * from wbhtable;
+                                                                         data
+    ----------------------------------------------------------------------------------------------------------------------------------------------
+     {"data": {"email": "test@example.com", "name": "John Doe", "user_id": "12345"}, "event": "user.signup", "timestamp": "2025-10-10T08:30:00Z"}
+    (1 row)
+    ```

--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -139,7 +139,7 @@ Format: <service name>.<namespace>.svc.<cluster domain>:4560
 
 ### Test webhook locally
 
-To test the webhook locally using Helm, first install a Helm release using the example command provided in [Helm Chart](/integrations/sources/webhook#helm-chart). For local testing, it is recommended to use **Orbstack** on macOS or **cloud testing clusters** on other platforms.
+To test the webhook locally using Helm, first install a Helm release using the example command provided in [Helm Chart](/integrations/sources/webhook#helm-chart).
 
 Once the Helm release is running, follow these steps:
 
@@ -181,7 +181,7 @@ Once the Helm release is running, follow these steps:
           }'
     ```
     
-4. Go back to step 2 and query from the table.
+4. Query from the table and check the result.
     
     ```bash
     psql -h localhost -p 4567 -d dev -U root

--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -69,7 +69,7 @@ RisingWave has been verified to work with the following webhook sources and auth
 |AWS EventBridge| Bearer Token |
 |Rudderstack| Bearer Token |
 
-Here are step-by-step guide to help you set up and configure your webhook sources:
+Here are step-by-step guides to help you set up and configure your webhook sources:
 
 - [Ingest from Github webhook](/integrations/sources/github-webhook)
 - [Ingest from Segment webhook](/integrations/sources/segment-webhook)

--- a/integrations/sources/webhook.mdx
+++ b/integrations/sources/webhook.mdx
@@ -100,11 +100,11 @@ Learn how to deploy and test RisingWave's webhook listener using open-source too
 
     You can try with the [base YAML](https://github.com/risingwavelabs/risingwave-operator/blob/main/docs/manifests/stable/persistent/minio/risingwave.yaml). 
 
-2. Apply the YAML to create RisingWave.
+2. Apply the YAML to create the RisingWave instance.
 
 **Endpoint (intra-Kubernetes)**
 
-The endpoint depends on the object name and namespace:
+Depending on the object name and namespace, the endpoint is typically:
 
 ```bash
 Example: risingwave-frontend.default.svc.cluster.local:4560
@@ -130,16 +130,18 @@ Format: <service name>.<namespace>.svc.<cluster domain>:4560
 
 **Endpoint (intra-Kubernetes)**
 
-Depending on the release name and namespace:
+Depending on the release name and namespace, the endpoint is typically:
 
 ```bash
 Example: risingwave.default.svc.cluster.local:4560
 Format: <service name>.<namespace>.svc.<cluster domain>:4560
 ```
 
-### Test webhook locally (Helm + Local)
+### Test webhook locally
 
-To test the webhook locally using Helm, first install a Helm release using the example command provided in [Helm Chart](/integrations/sources/webhook#helm-chart). For local testing, it is recommended to use Orbstack on macOS or cloud testing clusters on other platforms. Once the Helm release is running, follow these steps:
+To test the webhook locally using Helm, first install a Helm release using the example command provided in [Helm Chart](/integrations/sources/webhook#helm-chart). For local testing, it is recommended to use **Orbstack** on macOS or **cloud testing clusters** on other platforms.
+
+Once the Helm release is running, follow these steps:
 
 1. Forward ports of the RisingWave to local
     


### PR DESCRIPTION
## Description

Add guide for deploying and testing RisingWave webhook listener with Kubernetes and Helm, see [preview](https://risingwavelabs-wyx-update-webhook-deployment.mintlify.app/integrations/sources/webhook#deploy-risingwave-webhook-listener)

## Context

https://risingwave-labs.slack.com/archives/C03DFGV6L2W/p1760088205030849?thread_ts=1758105072.547139&cid=C03DFGV6L2W

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
