### PR TITLE
Document: support parsing STRUCT< > as empty struct

### DIFF
--- a/sql/data-types/struct.mdx
+++ b/sql/data-types/struct.mdx
@@ -10,7 +10,7 @@ Syntax:`STRUCT< >`
 Struct types are declared using the angle brackets (`<` and `>`).
 
 <Note>
-Starting from v2.7.0, RisingWave supports empty struct types, allowing you to define a struct with zero fields. To declare an empty struct, include a space between the angle brackets `< >`. This prevents conflicts with the `<>` (not equal) operator during SQL parsing.
+Starting from v2.7.0, RisingWave supports empty struct types, allowing you to define a struct with zero fields, serving as a placeholder for potential future additions of fields. To declare an empty struct, include a space between the angle brackets `< >`. This prevents conflicts with the `<>` (not equal) operator during SQL parsing.
 </Note>
 
 ### Examples

--- a/sql/data-types/struct.mdx
+++ b/sql/data-types/struct.mdx
@@ -9,6 +9,10 @@ Syntax:`STRUCT< >`
 
 Struct types are declared using the angle brackets (`<` and `>`).
 
+<Note>
+Starting from v2.7.0, RisingWave supports empty struct types, allowing you to define a struct with zero fields. To declare an empty struct, include a space between the angle brackets `< >`. This prevents conflicts with the `<>` (not equal) operator during SQL parsing.
+</Note>
+
 ### Examples
 
 The statement below creates a table `x` that contains struct `a`, which contains two nested columns (`b` and `c`) that are both integers.


### PR DESCRIPTION
## Description

As title

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/23099

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/653

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
