### PR TITLE
Fix: incorporate feedback for parquet doc

### DIFF
--- a/integrations/sources/azure-blob.mdx
+++ b/integrations/sources/azure-blob.mdx
@@ -67,7 +67,7 @@ Added in v2.3.0.
 You can use the table function `file_scan()` to read Parquet files from Azure Blob, either a single file or a directory of Parquet files.
 
 ```sql Function signature
-file_scan (parquet, azblob, account_name, account_key, endpoint, file_location)
+file_scan ('parquet', 'azblob', endpoint, account_name, account_key, file_location)
 ```
 
 <Note>

--- a/integrations/sources/google-cloud-storage.mdx
+++ b/integrations/sources/google-cloud-storage.mdx
@@ -84,10 +84,10 @@ Here are examples of connecting RisingWave to an GCS source to read data from in
     <Tab title="CSV">
 ```sql
 CREATE TABLE t(
-    "id" int,
-    "name" varchar,
-    "age" int,
-    "primary" key(id)
+    id int,
+    name varchar,
+    age int,
+    primary key(id)
 )
 INCLUDE file as file_name
 INCLUDE offset -- default column name is `_rw_gcs_offset`
@@ -104,10 +104,10 @@ WITH (
     <Tab title="JSON">
 ```sql
 CREATE TABLE t(
-    "id" int,
-    "name" TEXT,
-    "age" int,
-    "mark" int,
+    id int,
+    name TEXT,
+    age int,
+    mark int,
 )
 WITH (
     connector = 'gcs',
@@ -120,7 +120,7 @@ WITH (
 Use the `payload` keyword to ingest JSON data when you are unsure of the exact schema beforehand. Instead of defining specific column names and types at the very beginning, you can load all JSON data first and then prune and filter the data during runtime. Check the example below:
 
 ```sql
-CREATE TABLE table_include_payload ("v1" int, "v2" varchar)
+CREATE TABLE table_include_payload (v1 int, v2 varchar)
 INCLUDE payload
 WITH (
     connector = 'gcs',
@@ -134,9 +134,9 @@ WITH (
     <Tab title="PARQUET">
 ```sql
 CREATE TABLE t(
-    "id" int,
-    "name" varchar,
-    "age" int
+    id int,
+    name varchar,
+    age int
 )
 WITH (
     connector = 'gcs',

--- a/integrations/sources/google-cloud-storage.mdx
+++ b/integrations/sources/google-cloud-storage.mdx
@@ -71,7 +71,7 @@ Added in v2.3.0.
 You can use the table function `file_scan()` to read Parquet files from GCS, either a single file or a directory of Parquet files.
 
 ```sql Function signature
-file_scan (parquet, gcs, credential, service_account, file_location)
+file_scan ('parquet', 'gcs', credential, file_location_or_directory)
 ```
 
 <Note>
@@ -84,10 +84,10 @@ Here are examples of connecting RisingWave to an GCS source to read data from in
     <Tab title="CSV">
 ```sql
 CREATE TABLE t(
-    id int,
-    name varchar,
-    age int,
-    primary key(id)
+    "id" int,
+    "name" varchar,
+    "age" int,
+    "primary" key(id)
 )
 INCLUDE file as file_name
 INCLUDE offset -- default column name is `_rw_gcs_offset`
@@ -104,10 +104,10 @@ WITH (
     <Tab title="JSON">
 ```sql
 CREATE TABLE t(
-    id int,
-    name TEXT,
-    age int,
-    mark int,
+    "id" int,
+    "name" TEXT,
+    "age" int,
+    "mark" int,
 )
 WITH (
     connector = 'gcs',
@@ -120,7 +120,7 @@ WITH (
 Use the `payload` keyword to ingest JSON data when you are unsure of the exact schema beforehand. Instead of defining specific column names and types at the very beginning, you can load all JSON data first and then prune and filter the data during runtime. Check the example below:
 
 ```sql
-CREATE TABLE table_include_payload (v1 int, v2 varchar)
+CREATE TABLE table_include_payload ("v1" int, "v2" varchar)
 INCLUDE payload
 WITH (
     connector = 'gcs',
@@ -134,9 +134,9 @@ WITH (
     <Tab title="PARQUET">
 ```sql
 CREATE TABLE t(
-    id int,
-    name varchar,
-    age int
+    "id" int,
+    "name" varchar,
+    "age" int
 )
 WITH (
     connector = 'gcs',

--- a/integrations/sources/s3.mdx
+++ b/integrations/sources/s3.mdx
@@ -73,16 +73,20 @@ Empty cells in CSV files will be parsed to `NULL`.
 | `_file_`   | **Optional**. The column contains the file name where current record comes from.                                                |
 | `_offset_` | **Optional**. The column contains the corresponding bytes offset (record offset for parquet files) where current message begins |
 
-## Examples
+## Working with S3 sources
+
+Learn how to work with S3 sources through practical examples and scenarios. To avoid conflicts, double-quote all field names (e.g., `"field_name"`) when working with case-sensitive sources. For more conventions on naming and identifier handling, see [Identifiers](/sql/identifiers).
+
+### Basic examples
 
 Here are examples of connecting RisingWave to an S3 source to read data from individual streams.
 <Tabs>
   <Tab title="CSV">
 ```sql
 CREATE TABLE s(
-    "id" int,
-    "name" varchar,
-    "age" int
+    id int,
+    name varchar,
+    age int
 )
 WITH (
     connector = 's3',
@@ -97,13 +101,13 @@ WITH (
 
 ```
   </Tab>
-  <Tab title=" JSON">
+  <Tab title="JSON">
 ```sql
 CREATE TABLE s3(
-    "id" int,
-    "name" TEXT,
-    "age" int,
-    "mark" int,
+    id int,
+    name TEXT,
+    age int,
+    mark int,
 )
 INCLUDE file as file_name
 INCLUDE offset -- default column name is `_rw_s3_offset`
@@ -122,10 +126,7 @@ WITH (
 Use the `payload` keyword to ingest JSON data when you are unsure of the exact schema beforehand. Instead of defining specific column names and types at the very beginning, you can load all JSON data first and then prune and filter the data during runtime. Check the example below:
 
 ```sql
-CREATE TABLE table_include_payload(
-    "v1" int,
-    "v2" varchar
-)
+CREATE TABLE table_include_payload (v1 int, v2 varchar)
 INCLUDE payload
 WITH (
     connector = 's3',
@@ -139,9 +140,9 @@ WITH (
    <Tab title="PARQUET">
 ```sql
 CREATE TABLE s(
-    "id" int,
-    "name" varchar,
-    "age" int
+    id int,
+    name varchar,
+    age int
 )
 WITH (
     connector = 's3_v2',
@@ -157,10 +158,6 @@ WITH (
 </Tabs>
 
 
-
-
-## Important considerations
-
 ### Object filtering in S3 buckets
 
 RisingWave has a prefix argument designed for filtering objects in the S3 bucket. It relies on [Apache Opendal](https://github.com/apache/incubator-opendal) whose prefix filter implementation is expected to be released soon.
@@ -175,18 +172,34 @@ You need to create a materialized view from the source or create a table with th
 
 ```sql
 -- Create a materialized view from the source
-CREATE SOURCE s3_source WITH ( connector = 's3', ... );
+CREATE SOURCE s3_source (
+    product_id INT,
+    sales_date DATE,
+    quantity INT,
+    revenue DOUBLE
+) WITH (
+    connector = 's3',
+    ...
+);
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM s3_source;
 
 -- Create a table with the S3 connector
-CREATE TABLE s3_table ( ... ) WITH ( connector = 's3', ... );
+CREATE TABLE s3_table (
+    product_id INT,
+    sales_date DATE,
+    quantity INT,
+    revenue DOUBLE
+) WITH (
+    connector = 's3',
+    ...
+);
 
 -- Select from the source directly
 SELECT count(*) from s3_source;
 ```
 
 <Note>
-Column names and types are not inferred automatically from the Source. You must explicitly define them when creating the Table or Materialized View.
+Column names and types are not inferred automatically from the source. You must explicitly define them when creating the table or materialized view.
 </Note>
 
 ### Read Parquet files from S3
@@ -214,10 +227,10 @@ Read a single Parquet file
 
 ```sql
 SELECT
-  "product_id",
-  "sales_date",
-  "quantity",
-  "revenue"
+  product_id,
+  sales_date,
+  quantity,
+  revenue
 FROM file_scan(
   'parquet',
   's3',
@@ -242,10 +255,10 @@ Read a directory of Parquet files
 
 ```sql
 SELECT
-  "product_id",
-  "sales_date",
-  "quantity",
-  "revenue"
+  product_id,
+  sales_date,
+  quantity,
+  revenue
 FROM file_scan(
   'parquet',
   's3',

--- a/integrations/sources/s3.mdx
+++ b/integrations/sources/s3.mdx
@@ -80,9 +80,9 @@ Here are examples of connecting RisingWave to an S3 source to read data from ind
   <Tab title="CSV">
 ```sql
 CREATE TABLE s(
-    id int,
-    name varchar,
-    age int
+    "id" int,
+    "name" varchar,
+    "age" int
 )
 WITH (
     connector = 's3',
@@ -100,10 +100,10 @@ WITH (
   <Tab title=" JSON">
 ```sql
 CREATE TABLE s3(
-    id int,
-    name TEXT,
-    age int,
-    mark int,
+    "id" int,
+    "name" TEXT,
+    "age" int,
+    "mark" int,
 )
 INCLUDE file as file_name
 INCLUDE offset -- default column name is `_rw_s3_offset`
@@ -122,7 +122,10 @@ WITH (
 Use the `payload` keyword to ingest JSON data when you are unsure of the exact schema beforehand. Instead of defining specific column names and types at the very beginning, you can load all JSON data first and then prune and filter the data during runtime. Check the example below:
 
 ```sql
-CREATE TABLE table_include_payload (v1 int, v2 varchar)
+CREATE TABLE table_include_payload(
+    "v1" int,
+    "v2" varchar
+)
 INCLUDE payload
 WITH (
     connector = 's3',
@@ -136,9 +139,9 @@ WITH (
    <Tab title="PARQUET">
 ```sql
 CREATE TABLE s(
-    id int,
-    name varchar,
-    age int
+    "id" int,
+    "name" varchar,
+    "age" int
 )
 WITH (
     connector = 's3_v2',
@@ -182,12 +185,16 @@ CREATE TABLE s3_table ( ... ) WITH ( connector = 's3', ... );
 SELECT count(*) from s3_source;
 ```
 
-### Read Parquet files from S3[](#read-parquet-files-from-s3 "Direct link to Read Parquet files from S3")
+<Note>
+Column names and types are not inferred automatically from the Source. You must explicitly define them when creating the Table or Materialized View.
+</Note>
+
+### Read Parquet files from S3
 
 You can use the table function `file_scan()` to read Parquet files from S3, either a single file or a directory of Parquet files.
 
 ```sql Function signature
-file_scan(file_format, storage_type, s3_region, s3_access_key, s3_secret_key, file_location_or_directory)
+file_scan('parquet', 's3', s3_region, s3_access_key, s3_secret_key, file_location_or_directory)
 ```
 
 <Note>
@@ -207,10 +214,10 @@ Read a single Parquet file
 
 ```sql
 SELECT
-  product_id,
-  sales_date,
-  quantity,
-  revenue
+  "product_id",
+  "sales_date",
+  "quantity",
+  "revenue"
 FROM file_scan(
   'parquet',
   's3',
@@ -235,10 +242,10 @@ Read a directory of Parquet files
 
 ```sql
 SELECT
-  product_id,
-  sales_date,
-  quantity,
-  revenue
+  "product_id",
+  "sales_date",
+  "quantity",
+  "revenue"
 FROM file_scan(
   'parquet',
   's3',


### PR DESCRIPTION
## Description

See [context](https://www.notion.so/risingwave-labs/Mavin-Securities-Parquet-Batch-Test-2025-Nov-10-2a7f0d69cb7680edbaf4dbb34ddbee4a#2a8f0d69cb76809aac12c90a8b97f224) here

Feedback:

1. [[Example](https://docs.risingwave.com/integrations/sources/s3#examples)] should probably show it referencing column wrapped by quotes (only “column_name” worked for me for query and for DDL)
2. source cannot infer column names and types, [[but the docs seems to indicate that it can](https://docs.risingwave.com/integrations/sources/s3#read-data-from-the-source)]
3. for file_scan I needed to do “quotes” around the column name for parquet, but that’s not in the [[example](https://docs.risingwave.com/integrations/sources/s3#read-parquet-files-from-s3)]

Solution:

- For No.1 and No.3, it's all about quotes. Remind users to pay attention to double quotes, see `integrations/sources/s3.mdx` L76-79
- For No.2, remind users to define column names and types, see `integrations/sources/s3.mdx` L202, and update the code example as well

Let me know if any comments, thanks!


## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
