### PR TITLE
Fix: add `enable_config_load` for catalog parameters

### DIFF
--- a/iceberg/catalogs.mdx
+++ b/iceberg/catalogs.mdx
@@ -69,5 +69,5 @@ You specify the catalog configuration in the `WITH` clause of a `CREATE SOURCE`,
 | `catalog.rest.signing_region` | For Amazon S3 Tables: the AWS region for signing requests. |
 | `catalog.rest.signing_name` | For Amazon S3 Tables: the service name for signing requests. |
 | `catalog.rest.sigv4_enabled` | For Amazon S3 Tables: enables SigV4 signing. Must be `true`. |
-| `enable_config_load` | Controls whether configuration is loaded from environment variables. Set to `true` will load warehouse credentials from environment variables. Only supported in self-hosted environments. |
+| `enable_config_load` | If set to `true`, load warehouse credentials from environment variables. Only supported in self-hosted environments. |
 | `vended_credentials` | Enable vended credentials for a REST catalog. When set to `true` with `catalog.type = 'rest'`, requests credentials from the REST catalog server instead of managing them directly. Default: `false`. |

--- a/iceberg/catalogs.mdx
+++ b/iceberg/catalogs.mdx
@@ -69,4 +69,5 @@ You specify the catalog configuration in the `WITH` clause of a `CREATE SOURCE`,
 | `catalog.rest.signing_region` | For Amazon S3 Tables: the AWS region for signing requests. |
 | `catalog.rest.signing_name` | For Amazon S3 Tables: the service name for signing requests. |
 | `catalog.rest.sigv4_enabled` | For Amazon S3 Tables: enables SigV4 signing. Must be `true`. |
+| `enable_config_load` | Controls whether configuration is loaded from environment variables. Set to `true` will load warehouse credentials from environment variables. Only supported in self-hosted environments. |
 | `vended_credentials` | Enable vended credentials for a REST catalog. When set to `true` with `catalog.type = 'rest'`, requests credentials from the REST catalog server instead of managing them directly. Default: `false`. |

--- a/iceberg/catalogs/glue.mdx
+++ b/iceberg/catalogs/glue.mdx
@@ -28,3 +28,18 @@ CREATE SINK my_glue_sink FROM my_mv WITH (
     table.name = 'my_table'
 );
 ```
+
+If you prefer not to specify AWS credentials, you can set `enable_config_load = true` to load them from environment variables instead (self-hosted environments only).
+
+```sql
+CREATE SINK my_glue_sink FROM my_mv WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    catalog.type = 'glue',
+    warehouse.path = 's3://my-bucket/warehouse/',
+    enable_config_load = true, -- Load AWS credentials and region from environment variables
+    database.name = 'my_db',
+    table.name = 'my_table'
+);
+```

--- a/sql/commands/sql-create-connection.mdx
+++ b/sql/commands/sql-create-connection.mdx
@@ -106,7 +106,7 @@ For AWS authentication:
 | s3.path.style.access          | Enables path-style access for AWS S3. |
 | catalog.jdbc.user             | JDBC user for catalog access. |
 | catalog.jdbc.password         | JDBC password for catalog access. |
-| enable_config_load | Controls whether configuration is loaded from environment variables. Set to `true` will load warehouse credentials from environment variables. Only supported in self-hosted environments. |
+| enable_config_load | If set to `true`, load warehouse credentials from environment variables. Only supported in self-hosted environments. |
 
 </Accordion>
 


### PR DESCRIPTION
## Description

As title

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
