### PR TITLE
Document: file sink naming uses UUID instead of `executor_id`

### DIFF
--- a/delivery/overview.mdx
+++ b/delivery/overview.mdx
@@ -140,13 +140,17 @@ RisingWave implements batching strategies for file sinks, including [S3](/integr
 
 You can specify `path_partition_prefix` option in the `WITH` clause to organize files into subdirectories based on their creation time. The available options are month, day, or hour. If not specified, files will be stored directly in the root directory without any time-based subdirectories.
 
-Regarding file naming rules, currently, files follow the naming pattern `/Option<path_partition_prefix>/executor_id + timestamp.suffix`. `Timestamp` differentiates files batched by the rollover interval. 
-   
+Files follow the naming pattern `/Option<path_partition_prefix>/<uuid>_<timestamp>.<suffix>`. `Timestamp` differentiates files batched by the rollover interval. 
+
+<Note>
+Starting from v2.7.0, the file naming scheme replaces the previous `executor_id` component with a UUID.
+</Note>
+
 The output files look like below:
 
 ```
-path/2024-09-20/47244640257_1727072046.parquet
-path/2024-09-20/47244640257_1727072055.parquet
+path/2024-09-20/01935d2c-8f12-7890-abcd-ef1234567890_1727072046.parquet
+path/2024-09-20/01935d2c-8f12-7890-abcd-ef1234567890_1727072055.parquet
 ```
 
 ### Example

--- a/delivery/overview.mdx
+++ b/delivery/overview.mdx
@@ -143,7 +143,7 @@ You can specify `path_partition_prefix` option in the `WITH` clause to organize 
 Files follow the naming pattern `/Option<path_partition_prefix>/<uuid>_<timestamp>.<suffix>`. `Timestamp` differentiates files batched by the rollover interval. 
 
 <Note>
-Starting from v2.7.0, the file naming scheme replaces the previous `executor_id` component with a UUID.
+Starting from v2.7.0, the file naming scheme replaces the previous `executor_id` component with a UUID, meaning that further operations should no longer rely on `executor_id` in the filename.
 </Note>
 
 The output files look like below:


### PR DESCRIPTION
## Description

As title

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/23981

## Related doc issue

Fix https://github.com/risingwavelabs/risingwave-docs/issues/853

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
