### PR TITLE
clarify behavior of shared sources with `scan.startup.mode` set to `latest`

### DIFF
--- a/sql/commands/sql-create-source.mdx
+++ b/sql/commands/sql-create-source.mdx
@@ -189,7 +189,7 @@ This leads to increased resource usage and potential inconsistencies:
 
 With shared sources, when using the `CREATE SOURCE` statement:
 - It will instantiate a single `SourceExecutor` immediately. 
-- All materialized views referencing the same source share the `SourceExecutor`.
+- All materialized views referencing the same source share the `SourceExecutor`, thus the same start offset and consumption progress.
 - The downstream materialized views will only forwards data from the upstream sources, instead of consuming from Kafka independently.
 
 This improves resource utilization and consistency.
@@ -204,6 +204,7 @@ When creating a materialized view, RisingWave backfills historical data from Kaf
 
 - To monitoring backfill progress, use the [SHOW JOBS](/sql/commands/sql-show-jobs) command or check `Kafka Consumer Lag Size` in the Grafana dashboard (under `Streaming`).
 
+<Note>Even if the source is created with `scan.startup.mode` set to `latest`, the materialized view might still need to backfill data from the "latest" offset resolved when the source was initially created. If you want the materialized view to restart freshly from an existing source, you must drop and recreate the source to resolve a new start offset.</Note>
 
 <Note>If you set up a retention policy or if the external system can only be accessed once (like message queues), and the data is no longer available, any newly created materialized views won’t be able to backfill the complete historical data. This can lead to inconsistencies with earlier materialized views.</Note>
 

--- a/sql/commands/sql-create-source.mdx
+++ b/sql/commands/sql-create-source.mdx
@@ -204,7 +204,7 @@ When creating a materialized view, RisingWave backfills historical data from Kaf
 
 - To monitoring backfill progress, use the [SHOW JOBS](/sql/commands/sql-show-jobs) command or check `Kafka Consumer Lag Size` in the Grafana dashboard (under `Streaming`).
 
-<Note>Even if the source is created with `scan.startup.mode` set to `latest`, the materialized view might still need to backfill data from the "latest" offset resolved when the source was initially created. If you want the materialized view to restart freshly from an existing source, you must drop and recreate the source to resolve a new start offset.</Note>
+<Note>Even if a source is created with `scan.startup.mode` set to `latest`, a materialized view may still backfill from the offset resolved at source creation time. To start from the current latest offset, drop and recreate the source.</Note>
 
 <Note>If you set up a retention policy or if the external system can only be accessed once (like message queues), and the data is no longer available, any newly created materialized views won’t be able to backfill the complete historical data. This can lead to inconsistencies with earlier materialized views.</Note>
 


### PR DESCRIPTION
## Description

The behavior of `scan.startup.mode = 'latest'` with shared source is slightly different from non-shared source. In short:

- With non-shared source, a new job referencing the source will start ingestion from the latest offset resolved at the time **the job is created**. Different jobs referencing the same source may have different start offset, if they are created at different times.
- With shared source, a new job referencing the source will start ingestion from the latest offset resolved at the time **the source is created**. Different jobs referencing the same source have the same start offset, no matter when they are created (as long as data is not truncated or expired in upstream).

As a result, backfilling may still be required when creating a job referencing a shared source with `scan.startup.mode = 'latest'`, which might be surprising to users.

We may also update the documentation.

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/24253

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
