### PR TITLE
Fix: correct the version for small-files compaction type

### DIFF
--- a/iceberg/maintenance.mdx
+++ b/iceberg/maintenance.mdx
@@ -13,7 +13,7 @@ When RisingWave streams data into Iceberg, it generates many small data files an
 
 <Note>
 **Version notes**
-- RisingWave introduced Iceberg automatic maintenance in v2.5.0 and added files-with-delete compaction in v2.7.0.  
+- RisingWave introduced Iceberg automatic maintenance (default) in v2.5.0 and added `compaction.type` with the `small-files` and `files-with-delete` compaction types in v2.7.0.  
 - Parameters prefixed with `compaction` are currently in **[technical preview](/changelog/product-lifecycle#product-release-lifecycle)** stage and may change in future releases.
 </Note>
 


### PR DESCRIPTION
## Description

Context: https://risingwave-labs.slack.com/archives/C034XCYJPSN/p1767081236910569?thread_ts=1767079592.313459&cid=C034XCYJPSN

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
