### PR TITLE
Fix: broken link in Python UDFs

### DIFF
--- a/sql/udfs/use-udfs-in-python.mdx
+++ b/sql/udfs/use-udfs-in-python.mdx
@@ -105,7 +105,7 @@ Finally, the script starts a UDF server using `UdfServer` and listens for incomi
 
 <Note>
 
-For more examples of UDFs, such as functions handling complex data types like JSONB, see [this test file](https://github.com/risingwavelabs/risingwave/blob/main/e2e%5Ftest/udf/test.py) in RisingWave source code.
+For more examples of UDFs, such as functions handling complex data types like JSONB, see [this test file](https://github.com/risingwavelabs/risingwave/blob/main/e2e_test/udf/remote_python/test.py) in RisingWave source code.
 
 </Note>
 


### PR DESCRIPTION
## Description

Context: https://risingwave-labs.slack.com/archives/C034XCYJPSN/p1768205508780489

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
