### PR TITLE
Fix: update doc to align with code behavior

### DIFF
--- a/sql/commands/sql-create-source.mdx
+++ b/sql/commands/sql-create-source.mdx
@@ -79,15 +79,8 @@ Please distinguish between the parameters set in the FORMAT and ENCODE options a
 
 Different connectors have specific FORMAT and ENCODE requirements:
 
-- **CDC connectors** (e.g., `mysql-cdc`, `postgres-cdc`): Must use `FORMAT DEBEZIUM ENCODE JSON` (or `FORMAT PLAIN ENCODE JSON` for CDC source jobs). The FORMAT clause can be omitted as it defaults to the required format.
-
-- **Nexmark connector**: Must use `FORMAT NATIVE ENCODE NATIVE`. The FORMAT clause can be omitted.
-
-- **Datagen connector**: Defaults to `FORMAT NATIVE ENCODE NATIVE`, but other formats can be specified.
-
-- **Iceberg connector**: Uses `FORMAT NONE ENCODE NONE` (self-describing format). The FORMAT clause can be omitted.
-
-- **Other connectors** (Kafka, Kinesis, Pulsar, etc.): Require explicit FORMAT and ENCODE specification based on the actual data format.
+- For specialized connectors (CDC, Nexmark, Datagen, Iceberg), the FORMAT and ENCODE clauses are handled automatically and should be omitted.
+- For other connectors** (Kafka, Kinesis, Pulsar, etc.), you need to explicitly specify FORMAT and ENCODE specification based on the actual data format.
 
 If you specify an incompatible FORMAT for a connector, you will receive a parser error indicating the expected format.
 

--- a/sql/data-types/overview.mdx
+++ b/sql/data-types/overview.mdx
@@ -11,7 +11,7 @@ sidebarTitle: Overview
 | smallint |     | Two-byte integer | Range: -32768 to 32767 |
 | integer | int | Four-byte integer | Range: -2147483648 to 2147483647 |
 | bigint |     | Eight-byte integer | Range: -9223372036854775808 to 9223372036854775807 |
-| numeric | decimal | Exact numeric.  <br/>The syntax `NUMERIC(precision, scale)` is accepted by the parser for compatibility, but precision and scale are not enforced. All NUMERIC values use a fixed precision of 28 decimal digits. | Precision: 28 decimal digits. Note that the range is smaller compared to PostgreSQL. |
+| numeric | decimal | Exact numeric. <br/>We do not support specifying precision and scale as of now. | Precision: 28 decimal digits. Note that the range is smaller compared to PostgreSQL. |
 | real |     | Single precision floating-point number (4 bytes) | Range: 6 decimal digits precision |
 | double precision | double | Double precision floating-point number (8 bytes) | Range: 15 decimal digits precision |
 | character varying | varchar, string | Variable-length character string.  <br/>We do not support specifying the maximum length as of now. | Example: `'Hello World!'` |


### PR DESCRIPTION
## Description

This is the follow-up for https://github.com/risingwavelabs/risingwave-docs/pull/895/, reverted two changes based on the comments.

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
