### PR TITLE
docs(iceberg): clarify S3 auth + enable_config_load rules

### DIFF
--- a/iceberg/catalogs.mdx
+++ b/iceberg/catalogs.mdx
@@ -73,5 +73,5 @@ You specify the catalog configuration in the `WITH` clause of a `CREATE SOURCE`,
 | `glue.access.key` | The AWS access key ID for Glue authentication. If not specified, defaults to `s3.access.key`. |
 | `glue.secret.key` | The AWS secret access key for Glue authentication. If not specified, defaults to `s3.secret.key`. |
 | `glue.iam_role_arn` | The IAM role ARN to assume for Glue catalog access via STS. When set, the connector assumes the specified role for Glue catalog operations. |
-| `enable_config_load` | If set to `true`, load warehouse credentials from environment variables. Only supported in self-hosted environments. |
+| `enable_config_load` | If set to `true`, load AWS config/credentials from the environment (for example, to assume an IAM role via STS). |
 | `vended_credentials` | Enable vended credentials for a REST catalog. When set to `true` with `catalog.type = 'rest'`, requests credentials from the REST catalog server instead of managing them directly. Default: `false`. |

--- a/iceberg/catalogs/glue.mdx
+++ b/iceberg/catalogs/glue.mdx
@@ -12,160 +12,110 @@ For a complete list of all catalog-related parameters, see the main [Catalog con
 
 ## Example
 
-To create a sink that uses an AWS Glue catalog, set `catalog.type` to `'glue'` and provide your S3 warehouse path and AWS credentials.
+To use an AWS Glue catalog, set `catalog.type = 'glue'`. You also need S3 access for the Iceberg warehouse (`warehouse.path`).
+
+There are **two** ways to provide AWS credentials:
 
 ```sql
+-- Option 1: Access key / secret key (enable_config_load = false)
+-- Note: you may also set s3.iam_role_arn (optional).
 CREATE SINK my_glue_sink FROM my_mv WITH (
     connector = 'iceberg',
     type = 'upsert',
     primary_key = 'id',
     catalog.type = 'glue',
+    catalog.name = 'my_glue_catalog',
     warehouse.path = 's3://my-bucket/warehouse/',
     s3.region = 'us-west-2',
+    glue.region = 'us-west-2',
     s3.access.key = '...',
     s3.secret.key = '...',
+    enable_config_load = false,
     database.name = 'my_db',
     table.name = 'my_table'
 );
 ```
 
-If you prefer not to specify AWS credentials, you can set `enable_config_load = true` to load them from environment variables instead (self-hosted environments only).
-
 ```sql
+-- Option 2: IAM role (enable_config_load = true)
+-- Prereq: grant S3 permissions to your IAM role, then make sure the machine running this SQL
+-- can assume that role (via env/config). You can also specify the role explicitly with s3.iam_role_arn (optional).
 CREATE SINK my_glue_sink FROM my_mv WITH (
     connector = 'iceberg',
     type = 'upsert',
     primary_key = 'id',
     catalog.type = 'glue',
+    catalog.name = 'my_glue_catalog',
     warehouse.path = 's3://my-bucket/warehouse/',
-    enable_config_load = true, -- Load AWS credentials and region from environment variables
+    s3.region = 'us-west-2',
+    glue.region = 'us-west-2',
+    enable_config_load = true,
+    s3.iam_role_arn = 'arn:aws:iam::123456789012:role/MyS3Role', -- optional if already in env/config
     database.name = 'my_db',
     table.name = 'my_table'
 );
 ```
 
-## Using IAM roles with Glue catalog
+## Optional: Use separate permissions for S3 and Glue
 
 <Note>
-Added in v2.7.0.
+Support for `glue.*` IAM role parameters was added in v2.7.0.
 </Note>
 
-RisingWave provides two ways to authenticate with AWS Glue and S3 when using the Iceberg connector. This enables tighter security by allowing distinct IAM roles or credentials for each service.
+By default, if Glue-specific credentials/role are not provided, RisingWave falls back to using the S3 credentials/role.
 
-### Separate S3 and Glue credentials
+If you want to use different permissions for S3 and Glue, you can configure them separately. This still follows the same two authentication methods as above:
 
-You can configure S3 and Glue with independent credentials, using either access keys or IAM roles for each service.
-
-```sql Example of creating sink
+```sql
+-- Option 1 (separate AK/SK): enable_config_load = false
 CREATE SINK sink_t FROM t WITH (
     connector = 'iceberg',
     type = 'append-only',
     force_append_only = 'true',
 
+    catalog.type = 'glue',
+    catalog.name = 'demo',
+    warehouse.path = 's3://my-bucket/warehouse/',
     database.name = 'demo',
     table.name = 't',
-    catalog.name = 'demo',
-    catalog.type = 'glue',
-    warehouse.path = 'your_bucket',
 
-    -- S3 credentials or role
-    s3.endpoint = 'https://s3.ap-southeast-2.amazonaws.com',
+    -- S3 credentials
     s3.region = 'ap-southeast-2',
-    s3.access.key = 'xxx',
-    s3.secret.key = 'xxx',
-    s3.iam_role_arn = 'arn:aws:iam::xxx:role/Admin',
+    s3.access.key = '...',
+    s3.secret.key = '...',
 
-    -- Glue credentials or role
+    -- Glue credentials (optional; otherwise falls back to S3)
     glue.region = 'ap-southeast-2',
-    glue.access.key = 'xxx',
-    glue.secret.key = 'xxx',
-    glue.iam_role_arn = 'arn:aws:iam::xxx:role/Admin',
+    glue.access.key = '...',
+    glue.secret.key = '...',
 
-    -- `commit_checkpoint_interval` controls Iceberg commit frequency. Default: about every 60 seconds; set to 1 for faster commits and visibility.
-    commit_checkpoint_interval = 1,
-    create_table_if_not_exists = 'true'
+    enable_config_load = false
 );
 ```
 
-```sql Example of creating source
-CREATE SOURCE iceberg_t_source WITH (
-    connector = 'iceberg',
-
-    -- S3 credentials or role
-    s3.region = 'ap-southeast-2',
-    s3.access.key = 'xxx',
-    s3.secret.key = 'xxx',
-    s3.iam_role_arn = 'arn:aws:iam::xxx:role/Admin',
-
-    -- Glue credentials or role
-    glue.region = 'ap-southeast-2',
-    glue.access.key = 'xxx',
-    glue.secret.key = 'xxx',
-    glue.iam_role_arn = 'arn:aws:iam::xxx:role/Admin',
-
-    s3.path.style.access = 'true',
-
-    catalog.type = 'glue',
-    warehouse.path = 'your_bucket',
-    database.name = 'demo',
-    table.name = 't'
-);
-```
-
-If Glue-specific parameters are not provided, the connector falls back to using S3 credentials for backward compatibility.
-
-### Assume roles for S3 and Glue with `enable_config_load`
-
-When `enable_config_load = true` is enabled, RisingWave loads AWS config/credentials from the environment and assumes the IAM roles specified for S3 and Glue.
-
-```sql Example of creating sink
+```sql
+-- Option 2 (separate IAM roles): enable_config_load = true
+-- Prereq: the machine running this SQL can assume the roles (via env/config),
+-- or specify the roles explicitly with s3.iam_role_arn and glue.iam_role_arn.
 CREATE SINK sink_t FROM t WITH (
     connector = 'iceberg',
     type = 'append-only',
     force_append_only = 'true',
 
+    catalog.type = 'glue',
+    catalog.name = 'demo',
+    warehouse.path = 's3://my-bucket/warehouse/',
     database.name = 'demo',
     table.name = 't',
-    catalog.name = 'demo',
-    catalog.type = 'glue',
-    warehouse.path = 'your_path',
 
-    -- Assume role for S3
-    s3.endpoint = 'https://s3.ap-southeast-2.amazonaws.com',
+    -- S3 role (optional if already in env/config)
     s3.region = 'ap-southeast-2',
-    s3.iam_role_arn = 'arn:aws:iam::xxxx:role/Admin',
+    s3.iam_role_arn = 'arn:aws:iam::123456789012:role/MyS3Role',
 
-    -- Assume role for Glue
+    -- Glue role (optional; otherwise falls back to S3 role)
     glue.region = 'ap-southeast-2',
-    glue.iam_role_arn = 'arn:aws:iam::xxxx:role/Admin',
+    glue.iam_role_arn = 'arn:aws:iam::123456789012:role/MyGlueRole',
 
-    enable_config_load = true,
-
-    -- `commit_checkpoint_interval` controls Iceberg commit frequency. Default: about every 60 seconds; set to 1 for faster commits and visibility.
-    commit_checkpoint_interval = 1,
-    create_table_if_not_exists = 'true'
-);
-```
-
-```sql Example of creating source
-CREATE SOURCE iceberg_t_source WITH (
-    connector = 'iceberg',
-
-    -- Assume role for S3
-    s3.region = 'ap-southeast-2',
-    s3.iam_role_arn = 'arn:aws:iam::xxxx:role/Admin',
-
-    -- Assume role for Glue
-    glue.region = 'ap-southeast-2',
-    glue.iam_role_arn = 'arn:aws:iam::xxxx:role/Admin',
-
-    enable_config_load = true,
-
-    s3.path.style.access = 'true',
-
-    catalog.type = 'glue',
-    warehouse.path = 'your_path',
-    database.name = 'demo',
-    table.name = 't'
+    enable_config_load = true
 );
 ```

--- a/iceberg/catalogs/glue.mdx
+++ b/iceberg/catalogs/glue.mdx
@@ -95,7 +95,7 @@ CREATE SINK sink_t FROM t WITH (
 
 ```sql
 -- Option 2 (separate IAM roles): enable_config_load = true
--- Prereq: grant Glue and S3 permissions to your IAM role, then make sure the machine running this SQL can assume the roles (via env/config),
+-- Prereq: grant Glue and S3 permissions to your IAM roles, then make sure the machine running this SQL can assume the roles (via env/config),
 -- or specify the roles explicitly with s3.iam_role_arn and glue.iam_role_arn.
 CREATE SINK sink_t FROM t WITH (
     connector = 'iceberg',

--- a/iceberg/catalogs/glue.mdx
+++ b/iceberg/catalogs/glue.mdx
@@ -38,7 +38,7 @@ CREATE SINK my_glue_sink FROM my_mv WITH (
 
 ```sql
 -- Option 2: IAM role (enable_config_load = true)
--- Prereq: grant S3 permissions to your IAM role, then make sure the machine running this SQL
+-- Prereq: grant Glue and S3 permissions to your IAM role, then make sure the machine running this SQL
 -- can assume that role (via env/config). You can also specify the role explicitly with s3.iam_role_arn (optional).
 CREATE SINK my_glue_sink FROM my_mv WITH (
     connector = 'iceberg',
@@ -95,7 +95,7 @@ CREATE SINK sink_t FROM t WITH (
 
 ```sql
 -- Option 2 (separate IAM roles): enable_config_load = true
--- Prereq: the machine running this SQL can assume the roles (via env/config),
+-- Prereq: grant Glue and S3 permissions to your IAM role, then make sure the machine running this SQL can assume the roles (via env/config),
 -- or specify the roles explicitly with s3.iam_role_arn and glue.iam_role_arn.
 CREATE SINK sink_t FROM t WITH (
     connector = 'iceberg',

--- a/iceberg/catalogs/internal.mdx
+++ b/iceberg/catalogs/internal.mdx
@@ -9,11 +9,6 @@ RisingWave includes a built-in Iceberg catalog for internal Iceberg tables. It u
 <Note>
 **Prerequisite:** The built-in catalog (`hosted_catalog = true`) requires RisingWave’s metastore backend to be **PostgreSQL or MySQL**. **SQLite is not supported** for internal Iceberg tables with the built-in catalog.
 
-- **Docker Compose** uses PostgreSQL as the default metastore backend. See [Docker Compose deployment](/deploy/risingwave-docker-compose#customize-meta-store).
-- **RisingWave Cloud** is fully managed and provides a dedicated metastore. See [RisingWave Cloud](/deploy/risingwave-cloud).
-- **Docker Compose** uses PostgreSQL as the default metastore backend. See [Docker Compose deployment](/deploy/risingwave-docker-compose#customize-meta-store).
-- **Kubernetes (Helm)** can use PostgreSQL as the metastore backend (including the bundled PostgreSQL option). See [Deploy RisingWave with Helm](/deploy/risingwave-k8s-helm).
-
 If you use **Standalone mode**, RisingWave uses embedded SQLite for the metastore by default, so the built-in catalog is not supported by default. See [Standalone mode](/operate/rw-standalone-mode).
 </Note>
 

--- a/iceberg/internal-iceberg-tables.mdx
+++ b/iceberg/internal-iceberg-tables.mdx
@@ -24,11 +24,19 @@ You can also set the optional `commit_checkpoint_interval` parameter to control 
 
 When you create a `CONNECTION`, you specify the object storage backend where the table data will be stored. You also specify the catalog that will manage the table's metadata.
 
+<Note>
+For S3 credentials (applies to all catalogs):
+- If `enable_config_load = false`: you must provide `s3.access.key` and `s3.secret.key` (you may also set `s3.iam_role_arn`).
+- If `enable_config_load = true`: don’t provide `s3.access.key`/`s3.secret.key` (you may set `s3.iam_role_arn`, or rely on the role already available in your environment/config).
+
+See [Object storage configuration](/iceberg/object-storage).
+</Note>
+
 For more details on the available catalog options, see [Iceberg catalog configuration](/iceberg/catalogs).
 
 <Tabs>
     <Tab title="Built-in catalog">
-    For the simplest setup, use RisingWave's built-in JDBC-based catalog. This requires no external dependencies.
+    For the simplest setup, use RisingWave's built-in JDBC-based catalog (no separate catalog service to run).
     ```sql
     CREATE CONNECTION my_iceberg_conn WITH (
         type = 'iceberg',
@@ -103,7 +111,7 @@ For more details on the available catalog options, see [Iceberg catalog configur
 
 Create an internal Iceberg table using the `ENGINE = iceberg` clause.
 
-To create Iceberg tables, RisingWave needs to know which Iceberg `CONNECTION` to use (this connection contains both the object storage settings and the catalog settings). You can either set a default connection for the current session, or specify the connection per table.
+To create Iceberg tables, RisingWave needs to know which Iceberg `CONNECTION` to use (this connection contains both the object storage settings and the catalog settings). Choose **one** option below.
 
 ```sql
 -- Option 1: Set a default connection for the session

--- a/iceberg/object-storage.mdx
+++ b/iceberg/object-storage.mdx
@@ -14,14 +14,21 @@ These parameters configure the connection to an S3-compatible storage system, su
 |---|---|
 | `warehouse.path` | **Required**. The base path to your Iceberg warehouse. Example: `'s3://my-bucket/iceberg-warehouse'` |
 | `s3.region` | **Required**. The AWS region where the bucket is hosted. |
-| `s3.access.key` | **Conditional**. The AWS access key ID. |
-| `s3.secret.key` | **Conditional**. The AWS secret access key. |
-| `s3.iam_role_arn` | **Optional**. The IAM role ARN to assume for S3 access via STS. When set, the S3 FileIO layer assumes the specified role instead of using only the access key/secret pair, enabling tighter separation between object store access and other AWS permissions. |
+| `s3.access.key` | **Required when `enable_config_load = false`**. The AWS access key ID. |
+| `s3.secret.key` | **Required when `enable_config_load = false`**. The AWS secret access key. |
+| `s3.iam_role_arn` | **Optional**. The IAM role ARN to assume for S3 access via STS. Can be used with either `enable_config_load = false` or `true`. |
+| `enable_config_load` | **Optional**. If set to `true`, load AWS config/credentials from the environment (for example, to assume `s3.iam_role_arn`). When `enable_config_load = true`, do not provide `s3.access.key`/`s3.secret.key`. |
 | `s3.endpoint` | **Optional**. The endpoint for S3-compatible services like MinIO. For AWS S3, this is typically not needed. |
 | `s3.path.style.access` | **Optional**. Set to `true` to use path-style access (e.g., for MinIO). Defaults to `false` for virtual-hosted–style access. |
 
 <Note>
-In RisingWave Cloud, AWS credentials (`s3.access.key`, `s3.secret.key`) are required and cannot be omitted. In self-hosted deployments, you may omit them to rely on the AWS SDK default credential chain (for example, EC2 instance profile or environment variables).
+In RisingWave Cloud, you have two options:
+- Provide `s3.access.key` and `s3.secret.key`, or
+- Use IAM role delegation: grant S3 permissions to your own IAM role, allow the RisingWave Cloud tenant role to assume it, then set `s3.iam_role_arn = '<your_role_arn>'` and `enable_config_load = true`. The setup is the same as in the Snowflake sink guide: [Set up S3 IAM and role](/integrations/destinations/snowflake-v2#set-up-s3-iam-and-role).
+
+If you use a REST catalog with **vended credentials** (`vended_credentials = true`), you can omit S3 credentials here because the catalog server provides temporary credentials.
+
+In self-hosted deployments, if you want to rely on the AWS SDK default credential chain (for example, environment variables or an EC2 instance profile), set `enable_config_load = true` and omit `s3.access.key`/`s3.secret.key`.
 </Note>
 
 ## Google Cloud Storage (GCS)


### PR DESCRIPTION
This pull request updates the Iceberg catalog documentation to clarify AWS credential handling, especially around the `enable_config_load` parameter, and provides improved guidance and examples for configuring S3 and Glue authentication. The changes also clean up and clarify prerequisite notes and usage instructions for internal Iceberg tables.

**AWS credential configuration improvements:**

- Clarified the meaning and usage of the `enable_config_load` parameter for both S3 and Glue catalogs, specifying when credentials or IAM roles must be provided and how environment-based authentication works. [[1]](diffhunk://#diff-b80e0ed94326b6374917c42dd37372a651dcbde87878e4a7f34e33f1186d6c72L76-R76) [[2]](diffhunk://#diff-cbc1d31f3c8c7981849525af7677ab55042a8db37e02d18af13168c408d48494L17-R31) [[3]](diffhunk://#diff-eec24248b51fa7f1534fdfe2565a6bba5bc948571698a7753241ae7cb4c05222R27-R39)
- Expanded and reorganized example SQL configurations for AWS Glue catalogs to clearly distinguish between access key/secret key and IAM role-based authentication, and to show how to separately configure S3 and Glue credentials or roles.

**Internal Iceberg table documentation improvements:**

- Added a note in the internal Iceberg tables documentation summarizing S3 credential requirements for all catalog types, referencing the object storage configuration guide for further details.
- Clarified the explanation of how to specify the Iceberg `CONNECTION` when creating tables, making the instructions more explicit.

**General documentation cleanup:**

- Removed outdated or redundant notes about metastore backend requirements for the built-in catalog, streamlining the prerequisites section.