### PR TITLE
fix: add create_table_if_not_exists to iceberg sink

### DIFF
--- a/iceberg/catalogs/glue.mdx
+++ b/iceberg/catalogs/glue.mdx
@@ -57,6 +57,7 @@ CREATE SINK my_glue_sink FROM my_mv WITH (
 
     warehouse.path = 's3://my-bucket/warehouse/',
     database.name = 'my_db',
+    create_table_if_not_exists = 'true',
     table.name = 'my_table',
 
     catalog.type = 'glue',
@@ -164,6 +165,7 @@ CREATE SINK sink_t FROM t WITH (
     catalog.name = 'demo',
     warehouse.path = 's3://my-bucket/warehouse/',
     database.name = 'demo',
+    create_table_if_not_exists = 'true',
     table.name = 't',
 
     -- S3 credentials
@@ -193,6 +195,7 @@ CREATE SINK sink_t FROM t WITH (
     catalog.name = 'demo',
     warehouse.path = 's3://my-bucket/warehouse/',
     database.name = 'demo',
+    create_table_if_not_exists = 'true',
     table.name = 't',
 
     -- S3 role (optional if already in env/config)

--- a/iceberg/catalogs/hive.mdx
+++ b/iceberg/catalogs/hive.mdx
@@ -58,6 +58,7 @@ CREATE SINK my_hive_sink FROM my_mv WITH (
     s3.access.key = '...',
     s3.secret.key = '...',
     database.name = 'my_db',
+    create_table_if_not_exists = 'true',
     table.name = 'my_table'
 );
 ```
@@ -80,4 +81,3 @@ WITH (
 ```
   </Tab>
 </Tabs>
-

--- a/iceberg/catalogs/jdbc.mdx
+++ b/iceberg/catalogs/jdbc.mdx
@@ -56,6 +56,7 @@ CREATE SINK my_jdbc_sink FROM my_mv WITH (
     s3.access.key = '...',
     s3.secret.key = '...',
     database.name = 'my_db',
+    create_table_if_not_exists = 'true',
     table.name = 'my_table'
 );
 ```
@@ -79,4 +80,3 @@ CREATE SOURCE my_jdbc_source WITH (
 ```
   </Tab>
 </Tabs>
-

--- a/iceberg/catalogs/rest.mdx
+++ b/iceberg/catalogs/rest.mdx
@@ -54,6 +54,7 @@ CREATE SINK my_rest_sink FROM my_mv WITH (
     s3.access.key = '...',
     s3.secret.key = '...',
     database.name = 'my_db',
+    create_table_if_not_exists = 'true',
     table.name = 'my_table'
 );
 ```

--- a/iceberg/catalogs/s3-tables.mdx
+++ b/iceberg/catalogs/s3-tables.mdx
@@ -74,6 +74,7 @@ WITH (
     catalog.rest.sigv4_enabled = true,
     catalog.rest.signing_name = 's3tables',
     database.name = '<your-database-name>',
+    create_table_if_not_exists = 'true',
     table.name = '<your-table-name>'
 );
 ```
@@ -101,4 +102,3 @@ WITH (
 ```
   </Tab>
 </Tabs>
-

--- a/iceberg/catalogs/unity.mdx
+++ b/iceberg/catalogs/unity.mdx
@@ -30,6 +30,7 @@ WITH (
 
   warehouse.path = '<your-uc-catalog-name>',
   database.name = '<your-schema-name>',
+  create_table_if_not_exists = 'true',
   table.name = '<your-table-name>',
 
   catalog.type = 'rest',

--- a/iceberg/deliver-to-iceberg.mdx
+++ b/iceberg/deliver-to-iceberg.mdx
@@ -29,6 +29,7 @@ WITH (
     warehouse.path = 's3://my-data-lake/warehouse',
     database.name = 'analytics',
     table.name = 'processed_user_events',
+    create_table_if_not_exists = 'true',
     catalog.type = 'glue',
     catalog.name = 'my_glue_catalog',
     s3.access.key = 'your-access-key',
@@ -51,6 +52,7 @@ WITH (
 | `is_exactly_once`| No | Set to `true` to enable exactly-once delivery semantics. This provides stronger consistency but may impact performance. Default: `true`. <br/><br/> Exactly-once delivery requires [sink decoupling](/delivery/overview#sink-decoupling) to be enabled (the default behavior). If you `SET sink_decouple = false;`, exactly-once semantics will be automatically disabled for the sink.|
 | `commit_checkpoint_interval`| No | Controls how often RisingWave commits to Iceberg. Default: `60` (about every 60 seconds in the default configuration). |
 | `commit_retry_num`| No| The number of times to retry a failed commit. Default: `8`. |
+| `create_table_if_not_exists` | No | If `true`, RisingWave creates the external Iceberg table automatically when it does not exist. Default: `false`. |
 | `partition_by` | No | Specify partitioning using column names or transformations. Supported transformations include `identity`, `truncate(n)`, `bucket(n)`, `year`, `month`, `day`, `hour`, and `void`. Multiple columns can be separated by commas. Example: `partition_by = 'truncate(4,v2),bucket(5,v1)'`. For more details on Iceberg partitioning, see [Partition transforms](https://iceberg.apache.org/spec/#partition-transforms). |
 
 For detailed storage and catalog configuration:
@@ -74,4 +76,3 @@ SHOW SINKS;
 -- View sink details
 DESCRIBE SINK my_iceberg_sink;
 ```
-


### PR DESCRIPTION
## Description

Add `create_table_if_not_exists` to the iceberg sink doc, since it is a very important parameter, but missing recently.

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
