### PR TITLE
Add auto-assign issue workflow

### DIFF
--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -1,0 +1,19 @@
+name: Auto-assign Issues to Copilot
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assign-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Assign issue to copilot
+        run: |
+          gh issue edit ${{ github.event.issue.number }} --add-assignee "@copilot"
+        env:
+          GH_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that auto-assigns newly opened issues to @copilot.

## Related code PR

N/A

## Related doc issue

N/A

Fix N/A

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
