### PR TITLE
docs: Add best practice warning for DATE_TRUNC with temporal filters

### DIFF
--- a/processing/sql/temporal-filters.mdx
+++ b/processing/sql/temporal-filters.mdx
@@ -26,6 +26,10 @@ t <= NOW() - INTERVAL '1 hour' -- To delay event handling by 1 hour
 t < DATE_TRUNC('hour', NOW()) - INTERVAL '1 hour'
 ```
 
+<Note>
+When using `DATE_TRUNC` with temporal filters, be aware that the filter boundary advances in discrete steps (e.g., once per hour for `DATE_TRUNC('hour', ...)` or once per day for `DATE_TRUNC('day', ...)`). At each boundary crossing, all data accumulated since the last step expires at once, which can cause a sudden spike in processing load. The coarser the truncation granularity, the larger the spike. For high-throughput streams, prefer continuous ranges like `t > NOW() - INTERVAL '1 hour'` to distribute expirations evenly over time.
+</Note>
+
 There could be multiple temporal filters and other expressions in the `WHERE` clause conjoined with the `AND` operator.
 
 ```sql


### PR DESCRIPTION
## Summary

The temporal filters page shows `DATE_TRUNC('hour', NOW())` as a valid syntax example but doesn't mention the operational risk: because `DATE_TRUNC` causes the filter boundary to advance in discrete jumps rather than continuously, all data accumulated since the last step expires at once at each boundary crossing.

For example:
- `DATE_TRUNC('hour', ...)` — boundary jumps once per hour, expiring ~1 hour of data in one barrier
- `DATE_TRUNC('day', ...)` — boundary jumps once per day, expiring ~1 day of data in one barrier

This can overwhelm the `DynamicFilterExecutor` and cause barrier latency spikes, especially on high-throughput streams. Continuous ranges like `t > NOW() - INTERVAL '1 hour'` spread expirations evenly (one barrier interval's worth of data per tick).

This PR adds a `<Note>` after the `DATE_TRUNC` example to warn users about this behavior and recommend continuous ranges for high-throughput use cases.

## Changes
- `processing/sql/temporal-filters.mdx`: Added a Note block after the syntax examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)