### PR TITLE
docs: document Iceberg format v3 delete vector support (v2.8.0)

### DIFF
--- a/iceberg/iceberg-feature-support.mdx
+++ b/iceberg/iceberg-feature-support.mdx
@@ -26,6 +26,7 @@ description: "An overview of RisingWave's support for Apache Iceberg features, i
 | Dec 2025 | Vended credentials for Iceberg REST catalogs |
 | Dec 2025 | Enhanced Iceberg sink compaction strategies (small-files, files-with-delete) |
 | Dec 2025 | Refreshable Iceberg batch tables with scheduled or on-demand refresh |
+| Feb 2026 | Iceberg format v3 with delete vector support (read and write) |
 
 
 ## Feature comparison
@@ -58,7 +59,7 @@ The following table compares RisingWave with other ETL/ELT tools for Iceberg, su
 | Periodic loading (mutable, MoR) | Planned (v2.7) | Supported (via scheduled batch query) | Supported (via scheduled batch query) |
 | Continuous loading (append-only) | Supported | Supported | Supported |
 | Continuous loading (mutable, CoW) | Supported | Partially Supported (streams from new snapshots) | Supported (native changelog stream) |
-| Continuous loading (mutable, MoR) | Not Supported | Not Supported | Partially Supported (streams changes after compaction) |
+| Continuous loading (mutable, MoR) | Supported (v3 delete vectors, added Feb 2026) | Not Supported | Partially Supported (streams changes after compaction) |
 
 ## Key Iceberg features in RisingWave
 
@@ -73,7 +74,7 @@ The following table compares RisingWave with other ETL/ELT tools for Iceberg, su
 | Controllable Commit Frequency | Users can configure commit frequency based on workload and freshness requirements. | Balances performance, cost, and data freshness for diverse workloads. | Kafka / Kafka Connect |
 | Exactly-Once Semantics | Guarantees no duplicate or missing records while respecting primary key constraints from upstream sources. | Maintains strong data consistency and correctness in streaming pipelines. | Flink (no buffering, coupled with checkpoint) |
 | Embedded Log Store | Uses an internal log store (similar to an embedded Kafka) for buffering data before committing. | Enables durability, backpressure handling, and fault-tolerant data delivery. | Kafka / Kafka Connect |
-| Mutable Stream Modes | Supports two modes: MoR and CoW. MoR writes data and delete files for high freshness; CoW writes compacted data files for compatibility. | Offers flexibility to balance freshness and compatibility with different query engines. | - |
+| Mutable Stream Modes | Supports two modes: MoR and CoW. MoR writes data and delete files for high freshness; CoW writes compacted data files for compatibility. Iceberg format v3 introduces delete vectors (Puffin files) as a more efficient alternative to position/equality delete files, supported from Feb 2026. | Offers flexibility to balance freshness and compatibility with different query engines. Format v3 delete vectors reduce read amplification and are natively supported by Spark 4.0+ and Trino 470+. | - |
 | **Reading from Iceberg** | | | |
 | One-time Loading (Append-only) | Loads append-only Iceberg tables once for initial data import or snapshot analysis. | Ideal for bootstrapping analytical pipelines or ad-hoc analysis without maintaining state. | Spark, Flink |
 | One-time Loading (Mutable, CoW) | Loads CoW-style Iceberg tables once, applying overwrite semantics to ensure consistent snapshot reads. | Enables consistent point-in-time analysis for mutable tables. | Spark, Flink |

--- a/iceberg/write-modes.mdx
+++ b/iceberg/write-modes.mdx
@@ -147,3 +147,69 @@ Choose the write mode that best fits your workload and query patterns.
 | **Storage overhead** | Higher (stores base and delta files) | Lower (no separate delete files) |
 | **Default mode** | Yes | No |
 | **Ideal for** | Write-heavy workloads, real-time ingestion, append-only data | Read-heavy upsert workloads, BI dashboards |
+
+## Iceberg format version
+
+<Note>
+Iceberg format v3 (delete vectors) is available from v2.8.0.
+</Note>
+
+By default, RisingWave creates Iceberg tables and sinks using **Iceberg format version 2**. You can opt in to **format version 3**, which represents updates and deletes as _delete vectors_ encoded in [Puffin](https://iceberg.apache.org/puffin-spec/) files rather than as separate position or equality delete files.
+
+| | Format v2 | Format v3 |
+|---|---|---|
+| **Delete representation** | Separate position/equality delete files | Delete vectors (Puffin files co-located with data files) |
+| **MoR read overhead** | Requires joining base files with delete files | Vectorized apply — lower read-time CPU cost |
+| **Write efficiency** | Standard | Higher (smaller, more compact delete metadata) |
+| **Downstream compatibility** | Spark, Trino, Flink, DuckDB, etc. | Spark 4.0+, Trino 470+; check your engine's Iceberg v3 support |
+| **Default** | Yes | No (opt-in via `format_version = 3`) |
+
+### Enable format v3
+
+Set `format_version = 3` when creating an Iceberg table or sink:
+
+```sql
+-- Iceberg table engine with format v3
+CREATE TABLE orders (
+    id     INT PRIMARY KEY,
+    status VARCHAR,
+    amount NUMERIC
+) WITH (
+    format_version = 3,
+    commit_checkpoint_interval = 60
+) ENGINE = iceberg;
+```
+
+```sql
+-- Iceberg sink with format v3
+CREATE SINK orders_sink FROM my_source
+WITH (
+    connector = 'iceberg',
+    type = 'upsert',
+    primary_key = 'id',
+    warehouse.path = 's3://my-bucket/warehouse',
+    database.name = 'my_database',
+    table.name = 'orders',
+    catalog.type = 'storage',
+    s3.region = 'us-east-1',
+    format_version = 3
+);
+```
+
+### Verify delete vectors are being used
+
+Query the `rw_iceberg_files` system catalog to confirm that Puffin files (delete vectors) are present:
+
+```sql
+SELECT file_format, content, COUNT(*) AS file_count
+FROM rw_iceberg_files
+WHERE schema_name = 'public'
+  AND source_name = '__iceberg_source_orders'
+GROUP BY file_format, content;
+```
+
+When format v3 is active, you will see rows with `file_format = 'puffin'` for deleted rows, and no `EqualityDeletes` or `PositionDeletes` content entries.
+
+<Warning>
+`format_version` is set at table or sink creation time and cannot be changed afterward. Ensure your downstream query engines support Iceberg v3 before enabling this option.
+</Warning>


### PR DESCRIPTION
## Summary

Documents Iceberg format v3 (delete vectors) introduced in v2.8.0 ([risingwavelabs/risingwave#24470](https://github.com/risingwavelabs/risingwave/pull/24470)).

Format v3 represents deletes as Puffin-encoded delete vectors co-located with data files, replacing the separate position/equality delete file approach of v2. This reduces MoR read overhead and is natively supported by Spark 4.0+ and Trino 470+.

### Changes

- **`iceberg/iceberg-feature-support.mdx`**:
  - Add `Feb 2026` entry to the journey timeline.
  - Update *Continuous loading (mutable, MoR)* from `Not Supported` → `Supported (v3 delete vectors)`.
  - Expand the *Mutable Stream Modes* feature row to mention v3.

- **`iceberg/write-modes.mdx`**:
  - Add a new `## Iceberg format version` section with a v2 vs v3 comparison table, `format_version = 3` examples for both table engine and sink, and a `rw_iceberg_files` verification query.

### Related

- Source PR: risingwavelabs/risingwave#24470
- Part of the v2.8.0 monthly product update (3 PRs total)

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/risingwavelabs/risingwavelabs/editor/docs%2Ficeberg-v3-delete-vector?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->