### PR TITLE
docs: mark managed webhook ingestion as preview until 2.8

### DIFF
--- a/cloud/ingest-data-from-webhook.mdx
+++ b/cloud/ingest-data-from-webhook.mdx
@@ -6,7 +6,7 @@ description: "Use managed webhook endpoints in RisingWave Cloud to ingest webhoo
 This guide covers webhook ingestion for **managed RisingWave Cloud** projects, where requests are routed through the managed `rwproxy` webhook endpoint.
 
 <Warning>
-Webhook ingestion for managed RisingWave Cloud is currently in **preview**. General availability is planned for RisingWave 2.8. If you'd like to enable it before then, contact the team and we'll help you get set up.
+Webhook ingestion for managed RisingWave Cloud is currently in **preview**. General availability is planned for RisingWave 2.8. If you'd like to enable it before then, contact us at [cloud-support@risingwave-labs.com](mailto:cloud-support@risingwave-labs.com) and we'll help you get set up.
 </Warning>
 
 <Info>

--- a/cloud/ingest-data-from-webhook.mdx
+++ b/cloud/ingest-data-from-webhook.mdx
@@ -5,6 +5,10 @@ description: "Use managed webhook endpoints in RisingWave Cloud to ingest webhoo
 
 This guide covers webhook ingestion for **managed RisingWave Cloud** projects, where requests are routed through the managed `rwproxy` webhook endpoint.
 
+<Warning>
+Webhook ingestion for managed RisingWave Cloud is currently in **preview**. General availability is planned for RisingWave 2.8. If you'd like to enable it before then, contact the team and we'll help you get set up.
+</Warning>
+
 <Info>
 If you are running self-hosted RisingWave (Operator/Helm/bare metal), use [Ingest data from webhook](/integrations/sources/webhook).
 </Info>


### PR DESCRIPTION
Adds a warning callout to the managed webhook ingestion guide noting that the feature is in preview, GA is planned for 2.8, and users can contact the team to enable it early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)