### PR TITLE
docs: add warning for AWS Firewall Manager users before BYOC setup

### DIFF
--- a/cloud/project-byoc.mdx
+++ b/cloud/project-byoc.mdx
@@ -47,6 +47,10 @@ Follow the steps below to create your own cloud environment.
    If you're using AWS, ensure you're not using the AWS account root user for any deployment or operational tasks. Always use IAM users or roles with appropriate permissions instead.
    </Warning>
 
+   <Warning>
+   If you're using AWS with [AWS Firewall Manager (FMS)](https://docs.aws.amazon.com/fms/latest/userguide/what-is-fms.html) security group policies enabled, please contact our [support team](mailto:cloud-support@risingwave-labs.com) before creating a BYOC environment. FMS automatically attaches managed security groups to EC2 instances, which requires additional configuration to prevent node stability issues.
+   </Warning>
+
 4. Prepare the BYOC environment section. Click **Setup now** and follow the steps to set up your BYOC environment. Please note that the final command `rwc byoc apply --name xxx` may take 30 to 40 minutes to complete, and a progress bar will keep you informed of its progress. During this time, it's crucial to ensure a stable internet connection. If the command is interrupted or fails due to network instability, you can safely retry it.
    <Tip>
    When you run the command `rwc byoc apply --name xxx`, it will deploy some resources in your AWS/GCP/Azure environment, such as AWS S3/Google Cloud Storage/Azure Blob Storage and EKS/GKE/AKS clusters. Please do not modify the configuration of these resources. If you encounter any issues during this process, please contact our [support team](mailto:cloud-support@risingwave-labs.com).


### PR DESCRIPTION
## Summary

- Adds a warning in the "Create a BYOC environment" section for AWS users with FMS security group policies enabled
- Advises them to contact support before creating a BYOC environment, since FMS-managed security groups require additional Karpenter configuration to prevent node stability issues (SecurityGroupDrift)

Part of CLOUD-4598

## Test plan

- [ ] Verify the warning renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)