### PR TITLE
docs(sql): fix invalid materialized view GRANT/REVOKE examples

### DIFF
--- a/sql/commands/sql-grant.mdx
+++ b/sql/commands/sql-grant.mdx
@@ -118,11 +118,11 @@ ON ALL SOURCES IN SCHEMA schema1
 TO user1 GRANTED BY user;
 ```
 
-Grant the SELECT privilege for materialized view `mv1`, which is in schema `schema1` of database `db1`, to user `user1`. `user1` is able to grant the SELECT privilege other users.
+Grant the SELECT privilege for materialized view `schema1.mv1` to user `user1`. `user1` is able to grant the SELECT privilege to other users.
 
 ```sql
 GRANT SELECT
-ON MATERIALIZED VIEW mv1 IN SCHEMA db1.schema1
+ON MATERIALIZED VIEW schema1.mv1
 TO user1 WITH GRANT OPTION GRANTED BY user;
 ```
 

--- a/sql/commands/sql-revoke.mdx
+++ b/sql/commands/sql-revoke.mdx
@@ -105,7 +105,7 @@ ON ALL SOURCES IN SCHEMA schema1
 FROM user1 GRANTED BY user;
 ```
 
-REVOKE the SELECT privilege for materialized view `schema1.mv1` from user `user1`.
+Revoke the SELECT privilege for materialized view `schema1.mv1` from user `user1`.
 
 ```sql
 REVOKE SELECT

--- a/sql/commands/sql-revoke.mdx
+++ b/sql/commands/sql-revoke.mdx
@@ -105,11 +105,11 @@ ON ALL SOURCES IN SCHEMA schema1
 FROM user1 GRANTED BY user;
 ```
 
-REVOKE the SELECT privilege for materialized view `mv1`, which is in schema `schema1` of database `db1`, from user `user1`.
+REVOKE the SELECT privilege for materialized view `schema1.mv1` from user `user1`.
 
 ```sql
 REVOKE SELECT
-ON MATERIALIZED VIEW mv1 IN SCHEMA db1.schema1
+ON MATERIALIZED VIEW schema1.mv1
 FROM user1;
 ```
 


### PR DESCRIPTION
## Summary
- fix `GRANT` example that incorrectly used `ON MATERIALIZED VIEW mv1 IN SCHEMA ...`
- fix parallel `REVOKE` example with the same invalid pattern
- use schema-qualified object form: `ON MATERIALIZED VIEW schema1.mv1`

## Why
`IN SCHEMA` is valid for `ALL ... IN SCHEMA` forms, but not for granting/revoking a single object.

## Source
- Reported from Slack thread validation on March 13, 2026.

## Attribution
Collaborated with Jarvis (OpenAI Codex).
