### PR TITLE
docs(byoc): add comprehensive custom settings reference

### DIFF
--- a/cloud/project-byoc.mdx
+++ b/cloud/project-byoc.mdx
@@ -66,45 +66,60 @@ Once the cluster is successfully created, you can manage it through the portal j
 
 RisingWave provides several custom settings for BYOC deployments. To enable this feature, you need to create a configuration file containing the custom settings. These settings can be applied when creating a new BYOC environment or updating an existing one.
 
-Below are supported custom settings:
+Below are all supported custom settings:
 
-1. Container security context that applies to all RisingWave namespaces, including:
-   * `cloudagent` (hosting the agent service for Kubernetes operation delegation)
-   * `rwproxy` (hosting psql proxy for RisingWave clusters)
-   * `risingwave-operator-system` (hosting RisingWave operator managing the RisingWave cluster CRD)
-   * `rwc-*` (namespaces hosting RisingWave clusters)
+### General settings
 
-   For more information, please see [Security context](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext). 
+| Setting | Type | Description |
+| --- | --- | --- |
+| `container_security_context` | Object | Kubernetes [SecurityContext](https://pkg.go.dev/k8s.io/api/core/v1#SecurityContext) applied to all containers in RisingWave-managed namespaces: `cloudagent`, `rwproxy`, `risingwave-operator-system`, and `rwc-*`. |
+| `pod_security_admission_labels` | Map | [Pod Security Admission labels](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces) applied to all RisingWave-managed namespaces. |
+| `extra_tags` | Map | Custom tags applied to cloud vendor resources managed by RisingWave. |
+| `disable_external_cluster_access` | Boolean | When set to `true`, disables external (Internet-facing) access to RisingWave clusters. |
+### AWS settings (`aws_settings`)
 
-2. Namespace labels to enforce Pod Security Standard for all namespaces mentioned above.
+| Setting | Type | Description |
+| --- | --- | --- |
+| `eks_node_ami_release_version` | String | Custom AMI release version for EKS nodes. If omitted, the default AMI is used. |
 
-   For more information, please see [Pod Security Admission labels for namespaces](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces). 
+### Metrics settings (`metrics_settings`)
 
-3. Tags for Cloud vendor resources managed by RisingWave.
-
-4. AWS custom EKS AMI version for the EKS nodes.
+| Setting | Type | Description |
+| --- | --- | --- |
+| `discarded_risingwave_metrics_regex` | List | A list of regular expressions matching metric names to discard when scraping RisingWave. |
+| `risingwave_scraping_interval_secs` | Integer | Scraping interval in seconds for RisingWave metrics. |
 
 ### Create a configuration file
 
 1. Create a file at path `BYOC_CONFIG` with desired custom settings. You can include only the settings you need and omit others:
 
    ```yaml
+   # General settings
    container_security_context:
-   allowPrivilegeEscalation: false
-   capabilities:
-      drop:
-      - ALL
-   readOnlyRootFilesystem: true
-   runAsNonRoot: true
-   runAsUser: 65521
-   seccompProfile:
-      type: RuntimeDefault
+     allowPrivilegeEscalation: false
+     capabilities:
+       drop:
+         - ALL
+     readOnlyRootFilesystem: true
+     runAsNonRoot: true
+     runAsUser: 65521
+     seccompProfile:
+       type: RuntimeDefault
    pod_security_admission_labels:
-   pod-security.kubernetes.io/enforce: restricted
+     pod-security.kubernetes.io/enforce: restricted
    extra_tags:
-   foo: bar
+     foo: bar
+   disable_external_cluster_access: true
+
+   # AWS-specific settings
    aws_settings:
-   eks_node_ami_release_version: 1.32.0-20241225
+     eks_node_ami_release_version: 1.32.0-20241225
+
+   # Metrics settings
+   metrics_settings:
+     discarded_risingwave_metrics_regex:
+       - "^risingwave_.*_total$"
+     risingwave_scraping_interval_secs: 30
    ```
 
 2. Save the file path `$BYOC_CONFIG`, as you will use it in the later steps.


### PR DESCRIPTION
## Summary
- Replaced the brief numbered list of custom settings with structured tables documenting all public `BYOCCustomizedSettings` fields
- Added previously undocumented settings: `disable_external_cluster_access`, `metrics_settings` (`discarded_risingwave_metrics_regex`, `risingwave_scraping_interval_secs`)
- Updated the example YAML config to include all public settings with comments

## Test plan
- [ ] Verify the MDX renders correctly on the docs site
- [ ] Confirm all settings match the public fields in the `BYOCCustomizedSettings` struct in `risingwave-cloud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)