### PR TITLE
Add Wavelet documentation tab with full feature docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -899,6 +899,54 @@
             ]
           },
           {
+            "tab": "Wavelet",
+            "icon": "bolt",
+            "groups": [
+              {
+                "group": "Getting Started",
+                "pages": [
+                  "wavelet/overview",
+                  "wavelet/getting-started",
+                  "wavelet/config"
+                ]
+              },
+              {
+                "group": "CLI",
+                "pages": [
+                  "wavelet/cli"
+                ]
+              },
+              {
+                "group": "SDK",
+                "pages": [
+                  "wavelet/sdk/client",
+                  "wavelet/sdk/react"
+                ]
+              },
+              {
+                "group": "Server",
+                "pages": [
+                  "wavelet/server/http-api",
+                  "wavelet/server/websocket",
+                  "wavelet/server/jwt-auth"
+                ]
+              },
+              {
+                "group": "Data Sources",
+                "pages": [
+                  "wavelet/sources/postgres-cdc"
+                ]
+              },
+              {
+                "group": "Advanced",
+                "pages": [
+                  "wavelet/codegen",
+                  "wavelet/mcp"
+                ]
+              }
+            ]
+          },
+          {
             "tab": "Changelog",
             "groups": [
               {

--- a/wavelet/cli.mdx
+++ b/wavelet/cli.mdx
@@ -1,0 +1,142 @@
+---
+title: "Wavelet CLI reference"
+sidebarTitle: CLI
+description: "Reference for all Wavelet CLI commands — init, dev, push, generate, and status. Manage your Wavelet project from the terminal."
+---
+
+The Wavelet CLI manages your project lifecycle: initialize configs, run a dev server, sync DDL to RisingWave, and generate typed clients.
+
+```bash
+npm install @risingwave/wavelet-cli
+```
+
+## Commands
+
+### `wavelet init`
+
+Create a starter `wavelet.config.ts` in the current directory.
+
+```bash
+npx wavelet init
+```
+
+If a config file already exists, this command does nothing.
+
+### `wavelet dev`
+
+Start a local development server. This is the main command for local development.
+
+```bash
+npx wavelet dev [--config path]
+```
+
+What it does, in order:
+
+1. **Loads config** from `wavelet.config.ts` (or the path given by `--config`)
+2. **Starts RisingWave** if not already running — tries native binary first, then Docker
+3. **Syncs DDL** — creates/updates/deletes tables, materialized views, and subscriptions to match your config
+4. **Starts server** — HTTP API + WebSocket on the configured port (default `8080`)
+
+```
+$ npx wavelet dev
+✓ RisingWave is running
++ stream  game_events
++ view    leaderboard
++ sub     wavelet_sub_leaderboard
+Wavelet server listening on http://localhost:8080
+```
+
+The server runs until you press `Ctrl+C`. Shutdown is graceful — it closes WebSocket connections, cursors, and database connections in order.
+
+<Tip>
+If you don't have RisingWave installed, `wavelet dev` will try to start it via Docker automatically. Make sure Docker is running.
+</Tip>
+
+### `wavelet push`
+
+Sync your config to a RisingWave instance without starting a server. Use this for production deployments.
+
+```bash
+npx wavelet push [--config path] [--json]
+```
+
+Output:
+
+```
+$ npx wavelet push
++ stream  game_events
++ view    leaderboard
++ sub     wavelet_sub_leaderboard
+3 changes, 0 unchanged
+```
+
+The `--json` flag outputs structured JSON for CI/CD pipelines:
+
+```bash
+npx wavelet push --json
+```
+
+```json
+[
+  { "type": "create", "resource": "stream", "name": "game_events" },
+  { "type": "create", "resource": "view", "name": "leaderboard" },
+  { "type": "create", "resource": "subscription", "name": "wavelet_sub_leaderboard" }
+]
+```
+
+DDL sync is **idempotent** — running `push` multiple times with the same config produces no changes.
+
+### `wavelet generate`
+
+Generate a typed TypeScript client from your config.
+
+```bash
+npx wavelet generate [--config path]
+```
+
+Output file: `.wavelet/client.ts`
+
+The generated client includes:
+
+- **Row type interfaces** for each view (e.g., `LeaderboardRow`)
+- **Event type interfaces** for each stream (e.g., `GameEventsEvent`)
+- **`TypedWaveletClient`** class with typed `.views` and `.streams` accessors
+- **`ViewName`** literal union type
+- **`useWavelet` overloads** for React with per-view return types
+
+Type resolution uses a three-tier fallback:
+
+1. **Config-declared `columns`** — always available, no RisingWave needed
+2. **RisingWave introspection** — queries `information_schema.columns` if the database is reachable (3-second timeout)
+3. **Generic fallback** — `Record<string, unknown>` if neither is available
+
+<Tip>
+Add `columns` to your view definitions for reliable offline codegen without needing a running RisingWave.
+</Tip>
+
+### `wavelet status`
+
+Show config summary and connection status.
+
+```bash
+npx wavelet status [--config path]
+```
+
+```
+$ npx wavelet status
+Config: ./wavelet.config.ts
+Database: postgresql://root@localhost:4566/dev
+Streams: 1
+Views: 1
+  - leaderboard
+```
+
+Exits with code `1` if the config file cannot be loaded.
+
+## Global options
+
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Path to config file. Default: `./wavelet.config.ts` |
+| `--json` | Output structured JSON (supported by `push`) |
+| `--help`, `-h` | Show help |

--- a/wavelet/codegen.mdx
+++ b/wavelet/codegen.mdx
@@ -1,0 +1,175 @@
+---
+title: "Wavelet codegen"
+sidebarTitle: Codegen
+description: "Generate a fully typed TypeScript client from your Wavelet config. Type-safe views, streams, and React hooks with zero manual type definitions."
+---
+
+Wavelet generates a typed TypeScript client from your config. Instead of using string view names and `Record<string, unknown>`, you get typed row interfaces, typed stream events, and per-view React hook overloads.
+
+## Usage
+
+```bash
+npx wavelet generate
+```
+
+This reads your `wavelet.config.ts` and outputs `.wavelet/client.ts`.
+
+## What gets generated
+
+Given this config:
+
+```typescript wavelet.config.ts
+export default defineConfig({
+  database: 'postgresql://root@localhost:4566/dev',
+
+  streams: {
+    game_events: {
+      columns: { player_id: 'string', action: 'string', score: 'int' },
+    },
+  },
+
+  views: {
+    leaderboard: {
+      query: sql`SELECT player_id, SUM(score) AS total_score FROM game_events GROUP BY player_id`,
+      columns: { player_id: 'string', total_score: 'int' },
+    },
+  },
+})
+```
+
+The generated `.wavelet/client.ts` contains:
+
+```typescript .wavelet/client.ts
+// Row types for views
+export interface LeaderboardRow {
+  player_id: string
+  total_score: number
+}
+
+// Event types for streams
+export interface GameEventsEvent {
+  player_id: string
+  action: string
+  score: number
+}
+
+// Typed client
+export class TypedWaveletClient {
+  views = {
+    leaderboard: this.client.view<LeaderboardRow>('leaderboard'),
+  }
+  streams = {
+    game_events: this.client.stream<GameEventsEvent>('game_events'),
+  }
+}
+
+// View name literal type
+export type ViewName = 'leaderboard'
+
+// Typed React hook overloads
+export declare function useWavelet(view: 'leaderboard'): UseWaveletResult<LeaderboardRow>
+```
+
+## Type resolution
+
+Codegen uses a three-tier fallback to determine column types:
+
+### Tier 1: Config-declared columns
+
+If your view has a `columns` field, those types are used directly. No RisingWave connection needed.
+
+```typescript
+views: {
+  leaderboard: {
+    query: sql`...`,
+    columns: {              // ← Tier 1: always available
+      player_id: 'string',
+      total_score: 'int',
+    },
+  },
+}
+```
+
+### Tier 2: RisingWave introspection
+
+If no `columns` are declared but RisingWave is reachable, codegen queries `information_schema.columns` to discover the view's schema. Connection timeout is 3 seconds.
+
+### Tier 3: Generic fallback
+
+If neither is available, the view gets `Record<string, unknown>` — functional but untyped.
+
+<Tip>
+Add `columns` to your view definitions for reliable offline codegen. This is especially useful in CI/CD where RisingWave may not be running.
+</Tip>
+
+## Type mapping
+
+### From config `columns`
+
+| Config type | TypeScript type |
+|-------------|----------------|
+| `'string'` | `string` |
+| `'int'` | `number` |
+| `'float'` | `number` |
+| `'boolean'` | `boolean` |
+| `'timestamp'` | `string` |
+| `'json'` | `unknown` |
+
+### From RisingWave introspection
+
+| PostgreSQL type | TypeScript type |
+|-----------------|----------------|
+| `integer`, `bigint`, `smallint` | `number` |
+| `real`, `double precision`, `numeric` | `number` |
+| `boolean` | `boolean` |
+| `json`, `jsonb` | `unknown` |
+| `timestamp`, `timestamptz` | `string` |
+| Everything else | `string` |
+
+## Naming conventions
+
+| Config name | Generated interface |
+|-------------|-------------------|
+| `leaderboard` (view) | `LeaderboardRow` |
+| `game_events` (stream) | `GameEventsEvent` |
+| `user_order_summary` (view) | `UserOrderSummaryRow` |
+| `llm_events` (stream) | `LlmEventsEvent` |
+
+Names are converted to PascalCase. Views get a `Row` suffix, streams get an `Event` suffix.
+
+## Using the generated client
+
+```typescript
+import { TypedWaveletClient } from './.wavelet/client'
+
+const client = new TypedWaveletClient({ url: 'http://localhost:8080' })
+
+// Fully typed — autocomplete works
+const rows = await client.views.leaderboard.get()
+rows[0].player_id  // string
+rows[0].total_score // number
+
+await client.streams.game_events.emit({
+  player_id: 'alice',   // required: string
+  action: 'win',        // required: string
+  score: 100,           // required: number
+})
+```
+
+## Add to `.gitignore`
+
+The generated file should not be committed. Add to `.gitignore`:
+
+```
+.wavelet/
+```
+
+Regenerate it in CI or after `npm install`:
+
+```json package.json
+{
+  "scripts": {
+    "postinstall": "wavelet generate"
+  }
+}
+```

--- a/wavelet/config.mdx
+++ b/wavelet/config.mdx
@@ -1,0 +1,308 @@
+---
+title: "Wavelet configuration reference"
+sidebarTitle: Configuration
+description: "Complete reference for wavelet.config.ts — streams, views, sources, JWT, server options, column types, and the sql template tag."
+---
+
+All Wavelet behavior is driven by a single config file: `wavelet.config.ts`. This file is the source of truth for your streams, views, sources, and server settings. The CLI reads it, syncs it to RisingWave, and generates typed clients from it.
+
+## Basic structure
+
+```typescript wavelet.config.ts
+import { defineConfig, sql } from '@risingwave/wavelet'
+
+export default defineConfig({
+  database: 'postgresql://root@localhost:4566/dev',
+
+  streams: { /* input tables */ },
+  sources: { /* CDC sources */ },
+  views:   { /* materialized SQL queries */ },
+  jwt:     { /* authentication */ },
+  server:  { /* host and port */ },
+})
+```
+
+## `database`
+
+**Required.** RisingWave connection string.
+
+```typescript
+database: 'postgresql://root@localhost:4566/dev'
+```
+
+This is a standard PostgreSQL connection URL. Wavelet uses `pg` to connect.
+
+## `streams`
+
+Streams define input tables. You write events to streams via HTTP POST, and reference them in view queries.
+
+```typescript
+streams: {
+  page_views: {
+    columns: {
+      user_id: 'string',
+      url: 'string',
+      duration_ms: 'int',
+      metadata: 'json',
+      viewed_at: 'timestamp',
+    },
+  },
+}
+```
+
+Each stream becomes a RisingWave table. Column names map directly to SQL column names.
+
+### Column types
+
+| Type | RisingWave SQL type | TypeScript type |
+|------|-------------------|-----------------|
+| `'string'` | `VARCHAR` | `string` |
+| `'int'` | `INT` | `number` |
+| `'float'` | `DOUBLE` | `number` |
+| `'boolean'` | `BOOLEAN` | `boolean` |
+| `'timestamp'` | `TIMESTAMPTZ` | `string` |
+| `'json'` | `JSONB` | `unknown` |
+
+## `views`
+
+Views define materialized SQL queries. Wavelet creates RisingWave materialized views and subscriptions from these, then pushes diffs to WebSocket subscribers.
+
+### Full form
+
+```typescript
+views: {
+  active_users: {
+    query: sql`
+      SELECT user_id, COUNT(*) AS view_count
+      FROM page_views
+      WHERE viewed_at > NOW() - INTERVAL '1 hour'
+      GROUP BY user_id
+    `,
+    filterBy: 'user_id',
+    columns: {
+      user_id: 'string',
+      view_count: 'int',
+    },
+  },
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `query` | `SqlFragment` | Yes | SQL query using the `sql` tag |
+| `filterBy` | `string` | No | Column name for JWT-based per-tenant filtering |
+| `columns` | `Record<string, ColumnType>` | No | Column type hints for offline codegen |
+
+### Short form
+
+If you only need a query (no `filterBy` or `columns`), pass the `sql` fragment directly:
+
+```typescript
+views: {
+  total_views: sql`SELECT COUNT(*) AS total FROM page_views`,
+}
+```
+
+### `filterBy`
+
+When set, Wavelet matches the JWT token's claims against this column to filter diffs per-client. See [JWT auth](/wavelet/server/jwt-auth) for details.
+
+```typescript
+views: {
+  my_orders: {
+    query: sql`SELECT * FROM orders`,
+    filterBy: 'customer_id',
+    // Client with JWT claim { customer_id: "cust_123" }
+    // only receives rows where customer_id = "cust_123"
+  },
+}
+```
+
+### `columns`
+
+Optional type hints used by `wavelet generate` for offline codegen. Without these, codegen falls back to RisingWave introspection (requires a running instance) or `Record<string, unknown>`.
+
+```typescript
+views: {
+  leaderboard: {
+    query: sql`SELECT player_id, SUM(score) AS total FROM events GROUP BY player_id`,
+    columns: {
+      player_id: 'string',
+      total: 'int',
+    },
+  },
+}
+```
+
+## `sources`
+
+Sources connect to external databases via CDC. Currently supports PostgreSQL.
+
+```typescript
+sources: {
+  main_db: {
+    type: 'postgres',
+    connection: 'postgresql://user:pass@db.example.com:5432/myapp',
+    tables: ['users', 'orders', 'products'],
+    slotName: 'wavelet_main',
+    publicationName: 'wavelet_main_pub',
+  },
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `'postgres'` | Yes | — | Source type |
+| `connection` | `string` | Yes | — | PostgreSQL connection string |
+| `tables` | `string[]` | Yes | — | Tables to capture |
+| `slotName` | `string` | No | `wavelet_{sourceName}` | Replication slot name |
+| `publicationName` | `string` | No | `wavelet_{sourceName}_pub` | Publication name |
+
+CDC tables are created in RisingWave as `{sourceName}_{tableName}`. For example, `main_db` source with table `users` becomes `main_db_users` in RisingWave, which you can reference in view queries:
+
+```typescript
+views: {
+  user_order_summary: {
+    query: sql`
+      SELECT u.id, u.name, COUNT(o.id) AS order_count
+      FROM main_db_users u
+      JOIN main_db_orders o ON u.id = o.user_id
+      GROUP BY u.id, u.name
+    `,
+  },
+}
+```
+
+See [Postgres CDC sources](/wavelet/sources/postgres-cdc) for prerequisites and setup.
+
+## `jwt`
+
+JWT configuration for multi-tenant filtering. When configured, WebSocket clients must provide a valid token, and view diffs are filtered based on token claims.
+
+```typescript
+jwt: {
+  // Option A: shared secret (HS256)
+  secret: process.env.JWT_SECRET,
+
+  // Option B: JWKS endpoint (RS256, for Auth0/Clerk/etc.)
+  jwksUrl: 'https://your-auth.com/.well-known/jwks.json',
+
+  // Optional claim validation
+  issuer: 'https://your-auth.com/',
+  audience: 'your-app',
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `secret` | `string` | No | HS256 symmetric key for token verification |
+| `jwksUrl` | `string` | No | JWKS endpoint URL for RS256/ES256 verification |
+| `issuer` | `string` | No | Expected `iss` claim value |
+| `audience` | `string` | No | Expected `aud` claim value |
+
+Provide either `secret` or `jwksUrl`, not both. See [JWT auth](/wavelet/server/jwt-auth) for the full guide.
+
+## `server`
+
+Server host and port configuration.
+
+```typescript
+server: {
+  port: 3000,
+  host: '0.0.0.0',
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | `number` | `8080` | HTTP/WebSocket server port |
+| `host` | `string` | `'localhost'` | Bind address |
+
+## The `sql` tag
+
+The `sql` template tag creates `SqlFragment` objects. It supports interpolation:
+
+```typescript
+import { sql } from '@risingwave/wavelet'
+
+const interval = '1 hour'
+const view = {
+  query: sql`
+    SELECT user_id, COUNT(*) AS cnt
+    FROM events
+    WHERE ts > NOW() - INTERVAL '${interval}'
+    GROUP BY user_id
+  `,
+}
+```
+
+<Warning>
+The `sql` tag does **not** parameterize values — it concatenates them as strings. This is safe because config files are authored by developers, not user input. Do not pass untrusted input into `sql` template literals.
+</Warning>
+
+## Full example
+
+```typescript wavelet.config.ts
+import { defineConfig, sql } from '@risingwave/wavelet'
+
+export default defineConfig({
+  database: process.env.RISINGWAVE_URL ?? 'postgresql://root@localhost:4566/dev',
+
+  streams: {
+    llm_events: {
+      columns: {
+        tenant_id: 'string',
+        model: 'string',
+        tokens_in: 'int',
+        tokens_out: 'int',
+        cost_usd: 'float',
+        latency_ms: 'int',
+      },
+    },
+  },
+
+  sources: {
+    app_db: {
+      type: 'postgres',
+      connection: process.env.APP_DATABASE_URL!,
+      tables: ['tenants'],
+    },
+  },
+
+  views: {
+    tenant_usage: {
+      query: sql`
+        SELECT
+          tenant_id,
+          SUM(tokens_in + tokens_out) AS total_tokens,
+          SUM(cost_usd) AS total_cost,
+          COUNT(*) AS request_count
+        FROM llm_events
+        GROUP BY tenant_id
+      `,
+      filterBy: 'tenant_id',
+      columns: {
+        tenant_id: 'string',
+        total_tokens: 'int',
+        total_cost: 'float',
+        request_count: 'int',
+      },
+    },
+    model_stats: sql`
+      SELECT model, COUNT(*) AS calls, AVG(latency_ms) AS avg_latency
+      FROM llm_events
+      GROUP BY model
+    `,
+  },
+
+  jwt: {
+    jwksUrl: process.env.JWKS_URL,
+    issuer: process.env.JWT_ISSUER,
+  },
+
+  server: {
+    port: Number(process.env.PORT ?? 8080),
+    host: '0.0.0.0',
+  },
+})
+```

--- a/wavelet/docs-json-snippet.json
+++ b/wavelet/docs-json-snippet.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Add this tab to navigation.versions[0].tabs[] in docs.json",
+  "tab": "Wavelet",
+  "icon": "bolt",
+  "groups": [
+    {
+      "group": "Getting Started",
+      "pages": [
+        "wavelet/overview",
+        "wavelet/getting-started",
+        "wavelet/config"
+      ]
+    },
+    {
+      "group": "CLI",
+      "pages": [
+        "wavelet/cli"
+      ]
+    },
+    {
+      "group": "SDK",
+      "pages": [
+        "wavelet/sdk/client",
+        "wavelet/sdk/react"
+      ]
+    },
+    {
+      "group": "Server",
+      "pages": [
+        "wavelet/server/http-api",
+        "wavelet/server/websocket",
+        "wavelet/server/jwt-auth"
+      ]
+    },
+    {
+      "group": "Data Sources",
+      "pages": [
+        "wavelet/sources/postgres-cdc"
+      ]
+    },
+    {
+      "group": "Advanced",
+      "pages": [
+        "wavelet/codegen",
+        "wavelet/mcp"
+      ]
+    }
+  ]
+}

--- a/wavelet/getting-started.mdx
+++ b/wavelet/getting-started.mdx
@@ -1,0 +1,272 @@
+---
+title: "Get started with Wavelet"
+sidebarTitle: Getting started
+description: "Go from zero to a real-time leaderboard in 5 minutes. Install Wavelet, define a stream and view, start the dev server, write events, and subscribe to live results."
+---
+
+This guide walks you through building a real-time leaderboard. By the end, you will have a running Wavelet server that accepts game events over HTTP, computes a leaderboard in RisingWave, and pushes live updates over WebSocket.
+
+## Prerequisites
+
+- **Node.js** >= 20
+- **RisingWave** — Wavelet will start it automatically in dev mode if you have it [installed](/deploy/risingwave-docker-compose.mdx), or you can use Docker
+
+## 1. Create a project
+
+```bash
+mkdir my-app && cd my-app
+npm init -y
+npm install @risingwave/wavelet @risingwave/wavelet-cli
+```
+
+Generate a starter config:
+
+```bash
+npx wavelet init
+```
+
+This creates `wavelet.config.ts` in your project root.
+
+## 2. Define your config
+
+Edit `wavelet.config.ts`:
+
+```typescript wavelet.config.ts
+import { defineConfig, sql } from '@risingwave/wavelet'
+
+export default defineConfig({
+  database: 'postgresql://root@localhost:4566/dev',
+
+  streams: {
+    game_events: {
+      columns: {
+        player_id: 'string',
+        action: 'string',
+        score: 'int',
+      },
+    },
+  },
+
+  views: {
+    leaderboard: {
+      query: sql`
+        SELECT
+          player_id,
+          SUM(score) AS total_score,
+          COUNT(*) AS games_played
+        FROM game_events
+        GROUP BY player_id
+      `,
+    },
+  },
+})
+```
+
+<Tip>
+`defineConfig` provides TypeScript autocompletion for your config. The `sql` tag marks SQL strings so Wavelet can track them.
+</Tip>
+
+## 3. Start the dev server
+
+```bash
+npx wavelet dev
+```
+
+This will:
+1. Start RisingWave if it is not already running (native binary or Docker)
+2. Create the `game_events` table and `leaderboard` materialized view in RisingWave
+3. Start the Wavelet HTTP + WebSocket server on `http://localhost:8080`
+
+You should see output like:
+
+```
+✓ RisingWave is running
++ stream  game_events
++ view    leaderboard
++ sub     wavelet_sub_leaderboard
+Wavelet server listening on http://localhost:8080
+```
+
+## 4. Write events
+
+Send game events via HTTP POST:
+
+```bash
+# Single event
+curl -X POST http://localhost:8080/v1/streams/game_events \
+  -H "Content-Type: application/json" \
+  -d '{"player_id": "alice", "action": "win", "score": 100}'
+
+# Batch of events
+curl -X POST http://localhost:8080/v1/streams/game_events/batch \
+  -H "Content-Type: application/json" \
+  -d '[
+    {"player_id": "bob", "action": "win", "score": 75},
+    {"player_id": "alice", "action": "win", "score": 50}
+  ]'
+```
+
+## 5. Read the leaderboard
+
+Query the current state via HTTP GET:
+
+```bash
+curl http://localhost:8080/v1/views/leaderboard
+```
+
+Response:
+
+```json
+{
+  "rows": [
+    { "player_id": "alice", "total_score": 150, "games_played": 2 },
+    { "player_id": "bob", "total_score": 75, "games_played": 1 }
+  ]
+}
+```
+
+You can also filter with query parameters:
+
+```bash
+curl "http://localhost:8080/v1/views/leaderboard?player_id=alice"
+```
+
+## 6. Subscribe to live updates
+
+Connect to the WebSocket endpoint to receive real-time diffs:
+
+```javascript
+const ws = new WebSocket('ws://localhost:8080/subscribe/leaderboard')
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data)
+
+  if (msg.type === 'connected') {
+    console.log('Subscribed to', msg.view)
+  }
+
+  if (msg.type === 'diff') {
+    console.log('Inserted:', msg.inserted)
+    console.log('Updated:', msg.updated)
+    console.log('Deleted:', msg.deleted)
+  }
+}
+```
+
+Now send another event in a separate terminal:
+
+```bash
+curl -X POST http://localhost:8080/v1/streams/game_events \
+  -H "Content-Type: application/json" \
+  -d '{"player_id": "alice", "action": "win", "score": 200}'
+```
+
+Your WebSocket client will receive:
+
+```json
+{
+  "type": "diff",
+  "view": "leaderboard",
+  "cursor": "1711234567890",
+  "inserted": [],
+  "updated": [{ "player_id": "alice", "total_score": 350, "games_played": 3 }],
+  "deleted": []
+}
+```
+
+## 7. Use the TypeScript SDK
+
+Install the SDK:
+
+```bash
+npm install @risingwave/wavelet-sdk
+```
+
+Generate a typed client:
+
+```bash
+npx wavelet generate
+```
+
+This creates `.wavelet/client.ts` with typed interfaces for your views and streams.
+
+Use it in your app:
+
+```typescript
+import { WaveletClient } from '@risingwave/wavelet-sdk'
+
+const client = new WaveletClient({ url: 'http://localhost:8080' })
+
+// Read current leaderboard
+const rows = await client.view('leaderboard').get()
+
+// Subscribe to live updates
+const unsub = client.view('leaderboard').subscribe({
+  onData: (diff) => {
+    console.log('Changes:', diff.inserted, diff.updated, diff.deleted)
+  },
+})
+
+// Write an event
+await client.stream('game_events').emit({
+  player_id: 'charlie',
+  action: 'win',
+  score: 90,
+})
+```
+
+### React
+
+```bash
+npm install @risingwave/wavelet-sdk react
+```
+
+```tsx
+import { initWavelet, useWavelet } from '@risingwave/wavelet-sdk/react'
+
+// Initialize once at app startup
+initWavelet({ url: 'http://localhost:8080' })
+
+function Leaderboard() {
+  const { data, isLoading, error } = useWavelet('leaderboard', {
+    keyBy: 'player_id',
+  })
+
+  if (isLoading) return <div>Loading...</div>
+  if (error) return <div>Error: {error.message}</div>
+
+  return (
+    <ul>
+      {data.map((row) => (
+        <li key={row.player_id}>
+          {row.player_id}: {row.total_score}
+        </li>
+      ))}
+    </ul>
+  )
+}
+```
+
+<Tip>
+The `keyBy` option tells `useWavelet` which column is the primary key. This enables efficient O(n) merging of diffs using a Map instead of JSON comparison.
+</Tip>
+
+## 8. Deploy to production
+
+When you are ready to deploy, use `wavelet push` to sync your config against a production RisingWave instance:
+
+```bash
+npx wavelet push --config wavelet.config.ts
+```
+
+This applies the same idempotent DDL sync that `wavelet dev` uses — it diffs your config against the database and only makes necessary changes.
+
+## Next steps
+
+- [Configuration reference](/wavelet/config) — all config options
+- [CLI reference](/wavelet/cli) — all commands and flags
+- [TypeScript SDK](/wavelet/sdk/client) — client API details
+- [React hooks](/wavelet/sdk/react) — `useWavelet` in depth
+- [JWT multi-tenant filtering](/wavelet/server/jwt-auth) — per-user data isolation
+- [Postgres CDC sources](/wavelet/sources/postgres-cdc) — ingest from existing databases
+- [MCP for AI agents](/wavelet/mcp) — let agents query and write data

--- a/wavelet/mcp.mdx
+++ b/wavelet/mcp.mdx
@@ -1,0 +1,200 @@
+---
+title: "Wavelet MCP server for AI agents"
+sidebarTitle: MCP (AI agents)
+description: "Expose Wavelet views and streams to AI agents via Model Context Protocol. Agents can query real-time data, emit events, and run SQL — no HTTP client needed."
+---
+
+Wavelet includes an MCP (Model Context Protocol) server that lets AI agents interact with your views and streams using natural language tool calls. Agents can query computed results, write events, and run read-only SQL.
+
+```bash
+npm install @risingwave/wavelet-mcp
+```
+
+## Setup
+
+### Claude Code
+
+Add to your project's `.mcp.json`:
+
+```json .mcp.json
+{
+  "mcpServers": {
+    "wavelet": {
+      "command": "npx",
+      "args": ["wavelet-mcp"],
+      "env": {
+        "WAVELET_DATABASE_URL": "postgresql://root@localhost:4566/dev"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "wavelet": {
+      "command": "npx",
+      "args": ["wavelet-mcp"],
+      "env": {
+        "WAVELET_DATABASE_URL": "postgresql://root@localhost:4566/dev"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "wavelet": {
+      "command": "npx",
+      "args": ["wavelet-mcp"],
+      "env": {
+        "WAVELET_DATABASE_URL": "postgresql://root@localhost:4566/dev"
+      }
+    }
+  }
+}
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WAVELET_DATABASE_URL` | `postgresql://root@localhost:4566/dev` | RisingWave connection string |
+
+## Available tools
+
+The MCP server auto-discovers views and streams from RisingWave catalogs and exposes six tools:
+
+### `list_views`
+
+List all materialized views with their column schemas.
+
+```
+Agent: "What views are available?"
+→ list_views()
+→ { "views": [{ "name": "leaderboard", "columns": [{ "name": "player_id", "type": "varchar" }, ...] }] }
+```
+
+### `query_view`
+
+Query a materialized view with optional filtering.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `view` | `string` | Yes | View name |
+| `filter` | `object` | No | Key-value pairs for WHERE clause |
+| `limit` | `number` | No | Max rows (default: 100) |
+
+```
+Agent: "Show me Alice's leaderboard entry"
+→ query_view({ view: "leaderboard", filter: { player_id: "alice" } })
+→ { "view": "leaderboard", "rows": [{ "player_id": "alice", "total_score": 350 }], "count": 1 }
+```
+
+### `list_streams`
+
+List all event streams with their column schemas.
+
+```
+Agent: "What streams can I write to?"
+→ list_streams()
+→ { "streams": [{ "name": "game_events", "columns": [{ "name": "player_id", "type": "varchar" }, ...] }] }
+```
+
+### `emit_event`
+
+Write a single event to a stream.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `stream` | `string` | Yes | Stream name |
+| `data` | `object` | Yes | Event data (column-value pairs) |
+
+```
+Agent: "Record a win for Alice with score 100"
+→ emit_event({ stream: "game_events", data: { player_id: "alice", action: "win", score: 100 } })
+→ { "ok": true, "stream": "game_events" }
+```
+
+### `emit_batch`
+
+Write multiple events at once.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `stream` | `string` | Yes | Stream name |
+| `events` | `object[]` | Yes | Array of event objects |
+
+```
+Agent: "Record 3 game results"
+→ emit_batch({ stream: "game_events", events: [
+    { player_id: "alice", action: "win", score: 100 },
+    { player_id: "bob", action: "loss", score: -50 },
+    { player_id: "charlie", action: "win", score: 75 }
+  ]})
+→ { "ok": true, "stream": "game_events", "count": 3 }
+```
+
+### `run_sql`
+
+Execute a read-only SQL query against RisingWave.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sql` | `string` | Yes | SQL query (must start with `SELECT`) |
+
+```
+Agent: "What's the average score per action type?"
+→ run_sql({ sql: "SELECT action, AVG(score) as avg_score FROM game_events GROUP BY action" })
+→ { "rows": [{ "action": "win", "avg_score": 87.5 }, ...], "count": 2 }
+```
+
+<Warning>
+`run_sql` only accepts `SELECT` statements. `INSERT`, `UPDATE`, `DELETE`, and DDL statements are rejected.
+</Warning>
+
+## Use cases
+
+### Agent-driven monitoring
+
+An AI agent periodically checks `tenant_usage` to detect anomalies:
+
+```
+Agent: "Check if any tenant has spent more than $100 today"
+→ query_view({ view: "tenant_usage", filter: {} })
+→ Finds tenant with $142 spend, alerts the user
+```
+
+### Reactive agent behavior
+
+An agent writes events and reads results to make decisions:
+
+```
+Agent: "Add a game event and check the new leaderboard"
+→ emit_event({ stream: "game_events", data: { player_id: "alice", action: "win", score: 200 } })
+→ query_view({ view: "leaderboard" })
+→ "Alice is now #1 with 550 points"
+```
+
+### Data exploration
+
+An agent explores the data schema and runs ad-hoc queries:
+
+```
+Agent: "What data is available?"
+→ list_views() — sees leaderboard, model_stats
+→ list_streams() — sees game_events, llm_events
+→ run_sql({ sql: "SELECT COUNT(*) FROM game_events" })
+→ "There are 1,247 game events across 2 views and 2 streams"
+```

--- a/wavelet/overview.mdx
+++ b/wavelet/overview.mdx
@@ -1,0 +1,119 @@
+---
+title: "Wavelet — Real-time computed results for app developers"
+sidebarTitle: Overview
+description: "Subscribe to computed SQL results over WebSocket. Wavelet turns RisingWave materialized views into live APIs with typed SDKs, JWT multi-tenant filtering, and AI agent tooling."
+---
+
+Wavelet is a real-time backend that sits on top of [RisingWave](/get-started/intro.mdx). You define SQL views in a config file, and Wavelet turns them into live APIs that push diffs to your frontend over WebSocket.
+
+```
+App events ──▶ Wavelet HTTP API ──▶ RisingWave (stream processing)
+                                          │
+                                    Materialized Views
+                                          │
+                                   Wavelet Server ──▶ WebSocket diffs ──▶ React / any client
+```
+
+## What Wavelet does
+
+| Layer | What you get |
+|-------|-------------|
+| **Config** | Define streams (input tables) and views (SQL queries) in `wavelet.config.ts` |
+| **CLI** | `wavelet dev` starts RisingWave + syncs DDL + launches server. `wavelet push` deploys to production. |
+| **Server** | HTTP API for writes and reads. WebSocket fanout for real-time diffs. |
+| **SDK** | TypeScript client with `view.get()`, `view.subscribe()`, `stream.emit()`. React hook `useWavelet()`. |
+| **Codegen** | `wavelet generate` produces a fully typed client from your config. |
+| **MCP** | AI agents can query views and emit events via Model Context Protocol. |
+
+## Key concepts
+
+### Streams
+
+Streams are input tables. You write events to them via HTTP POST. Each stream has typed columns.
+
+```typescript
+streams: {
+  game_events: {
+    columns: {
+      player_id: 'string',
+      action: 'string',
+      score: 'int',
+    }
+  }
+}
+```
+
+### Views
+
+Views are materialized SQL queries over your streams (or CDC sources). Wavelet keeps them up to date in RisingWave and pushes diffs to subscribers.
+
+```typescript
+views: {
+  leaderboard: {
+    query: sql`
+      SELECT player_id, SUM(score) AS total_score
+      FROM game_events
+      GROUP BY player_id
+    `,
+  }
+}
+```
+
+### Diffs
+
+Instead of sending the full result set on every change, Wavelet sends diffs — which rows were inserted, updated, or deleted. Your client merges them into local state.
+
+```json
+{
+  "type": "diff",
+  "view": "leaderboard",
+  "inserted": [{ "player_id": "alice", "total_score": 150 }],
+  "updated":  [{ "player_id": "bob", "total_score": 320 }],
+  "deleted":  []
+}
+```
+
+### Sources
+
+Beyond HTTP writes, Wavelet can ingest data from existing PostgreSQL databases via CDC (Change Data Capture). Changes in your Postgres tables automatically flow into RisingWave.
+
+```typescript
+sources: {
+  main_db: {
+    type: 'postgres',
+    connection: 'postgresql://user:pass@host:5432/mydb',
+    tables: ['users', 'orders'],
+  }
+}
+```
+
+## How it works under the hood
+
+1. **DDL sync** — `DdlManager` reads your config, compares it against RisingWave's catalog, and applies minimal DDL changes (create/update/delete tables, materialized views, subscriptions).
+
+2. **Subscription cursors** — For each materialized view, Wavelet creates a RisingWave subscription and opens a blocking cursor (`FETCH NEXT ... WITH (timeout = '5s')`). When rows change, RisingWave pushes them through the cursor.
+
+3. **WebSocket fanout** — The cursor manager dispatches diffs to `WebSocketFanout`, which broadcasts to all connected clients. If JWT auth is configured, diffs are filtered per-client based on token claims.
+
+4. **Stateless** — All persistent state lives in RisingWave. Wavelet server keeps only cursor names and WebSocket connections in memory. On restart, cursors recover from RisingWave's 24-hour retention window.
+
+## When to use Wavelet
+
+Wavelet is a good fit when you need:
+
+- **Real-time dashboards** — leaderboards, analytics, monitoring
+- **Live feeds** — activity streams, notifications, chat
+- **Multi-tenant SaaS** — per-user data views with JWT filtering
+- **AI agent backends** — let agents query and write data via MCP
+
+Wavelet is not a general-purpose database or a replacement for your existing backend. It is a real-time compute layer that subscribes to changes and pushes results.
+
+## Packages
+
+| npm package | Purpose |
+|-------------|---------|
+| `@risingwave/wavelet` | `defineConfig`, `sql` tag, shared types |
+| `@risingwave/wavelet-server` | WebSocket fanout, HTTP API, DDL manager, JWT auth |
+| `@risingwave/wavelet-sdk` | TypeScript client + React hooks |
+| `@risingwave/wavelet-cli` | CLI (`wavelet dev`, `wavelet push`, codegen) |
+| `@risingwave/wavelet-mcp` | MCP server for AI agent integration |

--- a/wavelet/sdk/client.mdx
+++ b/wavelet/sdk/client.mdx
@@ -1,0 +1,223 @@
+---
+title: "Wavelet TypeScript SDK"
+sidebarTitle: TypeScript client
+description: "WaveletClient API reference — connect to Wavelet, subscribe to real-time view diffs, query views, and emit events from TypeScript."
+---
+
+The Wavelet TypeScript SDK provides a client for interacting with a Wavelet server. It handles HTTP requests, WebSocket subscriptions, JWT authentication, and automatic reconnection.
+
+```bash
+npm install @risingwave/wavelet-sdk
+```
+
+## WaveletClient
+
+```typescript
+import { WaveletClient } from '@risingwave/wavelet-sdk'
+
+const client = new WaveletClient({
+  url: 'http://localhost:8080',
+  token: 'your-jwt-token', // optional
+})
+```
+
+### Constructor options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `url` | `string` | Yes | Wavelet server URL (HTTP or WebSocket) |
+| `token` | `string \| () => string \| Promise<string>` | No | JWT token or token provider function |
+
+The `token` can be:
+
+- A **static string** — used as-is for all requests
+- A **function** — called before each request, useful for refreshing tokens
+
+```typescript
+// Static token
+const client = new WaveletClient({
+  url: 'http://localhost:8080',
+  token: 'eyJhbG...',
+})
+
+// Dynamic token (e.g., from your auth provider)
+const client = new WaveletClient({
+  url: 'http://localhost:8080',
+  token: async () => {
+    const session = await getSession()
+    return session.accessToken
+  },
+})
+```
+
+## Views
+
+### `client.view(name)`
+
+Returns a `ViewHandle` with `get()` and `subscribe()` methods.
+
+```typescript
+const leaderboard = client.view('leaderboard')
+```
+
+### `view.get(params?)`
+
+Fetch the current state of a view via HTTP GET.
+
+```typescript
+// All rows
+const rows = await client.view('leaderboard').get()
+
+// With query param filters
+const rows = await client.view('leaderboard').get({ player_id: 'alice' })
+```
+
+Returns `Promise<T[]>` where `T` defaults to `Record<string, unknown>`.
+
+**Errors:**
+- `VIEW_NOT_FOUND` — the view does not exist
+- `AUTH_ERROR` — invalid or missing token (when JWT is configured)
+- `SERVER_ERROR` — other server errors
+
+### `view.subscribe(handlers)`
+
+Subscribe to real-time diffs via WebSocket. Returns an `unsubscribe` function.
+
+```typescript
+const unsub = client.view('leaderboard').subscribe({
+  onData: (diff) => {
+    console.log('Inserted:', diff.inserted)
+    console.log('Updated:', diff.updated)
+    console.log('Deleted:', diff.deleted)
+    console.log('Cursor:', diff.cursor)
+  },
+  onError: (error) => {
+    console.error(error.code, error.message)
+  },
+  onReconnect: () => {
+    console.log('Reconnected')
+  },
+})
+
+// Later: stop subscription
+unsub()
+```
+
+| Handler | Type | Required | Description |
+|---------|------|----------|-------------|
+| `onData` | `(diff: Diff<T>) => void` | Yes | Called on each diff from the server |
+| `onError` | `(error: WaveletError) => void` | No | Called on errors (auth failures, parse errors) |
+| `onReconnect` | `() => void` | No | Called when WebSocket reconnects after a disconnect |
+
+**Automatic reconnection:** If the WebSocket disconnects unexpectedly, the client reconnects with exponential backoff (1s, 2s, 4s, ... up to 30s). It passes the last received cursor to resume from where it left off.
+
+**Auth rejection (code 4000):** If the server rejects the connection (invalid token, view not found), the client does **not** reconnect. It calls `onError` instead.
+
+### `Diff<T>`
+
+The diff object received by `onData`:
+
+```typescript
+interface Diff<T> {
+  cursor: string     // RisingWave timestamp of this diff
+  inserted: T[]      // New rows
+  updated: T[]       // Changed rows (new values)
+  deleted: T[]       // Removed rows
+}
+```
+
+## Streams
+
+### `client.stream(name)`
+
+Returns a `StreamHandle` with `emit()` and `emitBatch()` methods.
+
+```typescript
+const events = client.stream('game_events')
+```
+
+### `stream.emit(data)`
+
+Write a single event via HTTP POST.
+
+```typescript
+await client.stream('game_events').emit({
+  player_id: 'alice',
+  action: 'win',
+  score: 100,
+})
+```
+
+### `stream.emitBatch(data)`
+
+Write multiple events in one request via HTTP POST.
+
+```typescript
+await client.stream('game_events').emitBatch([
+  { player_id: 'alice', action: 'win', score: 100 },
+  { player_id: 'bob', action: 'loss', score: -50 },
+])
+```
+
+## Type safety with codegen
+
+Run `npx wavelet generate` to produce `.wavelet/client.ts` with typed interfaces. Then use generics:
+
+```typescript
+import { WaveletClient } from '@risingwave/wavelet-sdk'
+import type { LeaderboardRow, GameEventsEvent } from './.wavelet/client'
+
+const client = new WaveletClient({ url: 'http://localhost:8080' })
+
+// Typed view — rows are LeaderboardRow[]
+const rows = await client.view<LeaderboardRow>('leaderboard').get()
+
+// Typed stream — emit is type-checked
+await client.stream<GameEventsEvent>('game_events').emit({
+  player_id: 'alice',
+  action: 'win',
+  score: 100,
+})
+
+// Typed subscription — diff.inserted is LeaderboardRow[]
+client.view<LeaderboardRow>('leaderboard').subscribe({
+  onData: (diff) => {
+    diff.inserted.forEach((row) => {
+      console.log(row.player_id, row.total_score) // fully typed
+    })
+  },
+})
+```
+
+Or use the generated `TypedWaveletClient` for full type safety without generics:
+
+```typescript
+import { TypedWaveletClient } from './.wavelet/client'
+
+const client = new TypedWaveletClient({ url: 'http://localhost:8080' })
+
+// Autocomplete works — views.leaderboard, streams.game_events
+const rows = await client.views.leaderboard.get()
+await client.streams.game_events.emit({ player_id: 'alice', action: 'win', score: 100 })
+```
+
+## Error handling
+
+All SDK errors are `WaveletError` instances with a `code` property:
+
+```typescript
+import { WaveletError } from '@risingwave/wavelet-sdk'
+
+try {
+  await client.view('nonexistent').get()
+} catch (err) {
+  if (err instanceof WaveletError) {
+    switch (err.code) {
+      case 'AUTH_ERROR':        // 401 or WebSocket 4000
+      case 'VIEW_NOT_FOUND':   // 404
+      case 'CONNECTION_ERROR': // client not initialized
+      case 'SERVER_ERROR':     // other errors
+    }
+  }
+}
+```

--- a/wavelet/sdk/react.mdx
+++ b/wavelet/sdk/react.mdx
@@ -1,0 +1,158 @@
+---
+title: "Wavelet React hooks"
+sidebarTitle: React hooks
+description: "useWavelet React hook — subscribe to real-time view data with automatic state management, diff merging, and loading/error states."
+---
+
+Wavelet provides a React hook that fetches the initial state of a view and subscribes to real-time updates. State is managed internally — your component re-renders when data changes.
+
+```bash
+npm install @risingwave/wavelet-sdk react
+```
+
+## Setup
+
+Initialize the global Wavelet client once at your app's entry point:
+
+```tsx app.tsx
+import { initWavelet } from '@risingwave/wavelet-sdk/react'
+
+initWavelet({
+  url: 'http://localhost:8080',
+  token: () => getAuthToken(), // optional
+})
+```
+
+<Warning>
+Call `initWavelet` before any component renders. If a component calls `useWavelet` before initialization, it throws a `CONNECTION_ERROR`.
+</Warning>
+
+## `useWavelet`
+
+```typescript
+function useWavelet<T>(
+  viewName: string,
+  options?: UseWaveletOptions
+): UseWaveletResult<T>
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `viewName` | `string` | Yes | Name of the view to subscribe to |
+| `options.keyBy` | `string` | No | Column to use as primary key for efficient merging |
+| `options.params` | `Record<string, string>` | No | Query parameters for the initial HTTP fetch |
+
+### Return value
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `data` | `T[]` | Current rows, updated in real time |
+| `isLoading` | `boolean` | `true` until the initial HTTP fetch completes |
+| `error` | `WaveletError \| null` | Error from fetch, subscription, or auth |
+
+### Basic usage
+
+```tsx
+import { useWavelet } from '@risingwave/wavelet-sdk/react'
+
+function Leaderboard() {
+  const { data, isLoading, error } = useWavelet('leaderboard')
+
+  if (isLoading) return <p>Loading...</p>
+  if (error) return <p>Error: {error.message}</p>
+
+  return (
+    <table>
+      <thead>
+        <tr><th>Player</th><th>Score</th></tr>
+      </thead>
+      <tbody>
+        {data.map((row, i) => (
+          <tr key={i}>
+            <td>{row.player_id}</td>
+            <td>{row.total_score}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+```
+
+### `keyBy` — efficient diff merging
+
+Without `keyBy`, diffs are merged using JSON comparison (`JSON.stringify`), which works but is O(n*m) for deletions. With `keyBy`, merging uses a Map keyed by the specified column — O(n) for all operations.
+
+```tsx
+// Uses Map<player_id, row> for O(n) merging
+const { data } = useWavelet('leaderboard', { keyBy: 'player_id' })
+```
+
+**Always use `keyBy` when your view has a natural primary key.** This is more efficient and avoids edge cases with JSON comparison.
+
+### `params` — filtered initial fetch
+
+Pass query parameters to filter the initial HTTP GET. The WebSocket subscription still receives all diffs (filtered server-side by JWT if configured).
+
+```tsx
+const { data } = useWavelet('orders', {
+  keyBy: 'order_id',
+  params: { status: 'pending' },
+})
+```
+
+## How it works
+
+1. **Initial fetch** — `useWavelet` calls `view.get(params)` via HTTP to load the current snapshot
+2. **Subscribe** — simultaneously opens a WebSocket subscription to receive diffs
+3. **Merge** — each diff is merged into the local state using `keyBy` (Map-based) or naive (JSON-based) strategy
+4. **Re-render** — React state is updated, component re-renders with new data
+
+The hook cleans up the WebSocket subscription when the component unmounts or when `viewName`/`keyBy`/`params` change.
+
+## With codegen types
+
+After running `npx wavelet generate`, the generated client includes typed overloads:
+
+```tsx
+// .wavelet/client.ts provides typed useWavelet overloads
+import { useWavelet } from './.wavelet/client'
+
+function Dashboard() {
+  // Return type is UseWaveletResult<TenantUsageRow> — fully typed
+  const { data } = useWavelet('tenant_usage')
+
+  return (
+    <div>
+      {data.map((row) => (
+        // row.total_tokens, row.total_cost, etc. — all typed
+        <p key={row.tenant_id}>{row.tenant_id}: {row.total_tokens} tokens</p>
+      ))}
+    </div>
+  )
+}
+```
+
+## Multiple views
+
+Subscribe to multiple views in the same component:
+
+```tsx
+function Dashboard() {
+  const leaderboard = useWavelet('leaderboard', { keyBy: 'player_id' })
+  const stats = useWavelet('model_stats', { keyBy: 'model' })
+
+  if (leaderboard.isLoading || stats.isLoading) return <p>Loading...</p>
+
+  return (
+    <>
+      <LeaderboardTable data={leaderboard.data} />
+      <StatsTable data={stats.data} />
+    </>
+  )
+}
+```
+
+Each `useWavelet` call opens its own WebSocket connection and manages its own state independently.

--- a/wavelet/server/http-api.mdx
+++ b/wavelet/server/http-api.mdx
@@ -1,0 +1,162 @@
+---
+title: "Wavelet HTTP API reference"
+sidebarTitle: HTTP API
+description: "Wavelet HTTP API — health check, list views and streams, query view data, write single and batch events. Full endpoint reference with examples."
+---
+
+Wavelet exposes a REST API for reading views, writing events, and checking server health. All responses are JSON. CORS is enabled by default (all origins).
+
+Base URL: `http://localhost:8080` (configurable via `server.port` and `server.host` in your config).
+
+## Endpoints
+
+### Health check
+
+```
+GET /v1/health
+```
+
+```json
+{ "status": "ok" }
+```
+
+### List views
+
+```
+GET /v1/views
+```
+
+Returns all available view names.
+
+```json
+{ "views": ["leaderboard", "model_stats"] }
+```
+
+### List streams
+
+```
+GET /v1/streams
+```
+
+Returns all available stream names.
+
+```json
+{ "streams": ["game_events", "llm_events"] }
+```
+
+### Query a view
+
+```
+GET /v1/views/{name}
+```
+
+Returns the current rows of a materialized view.
+
+```bash
+curl http://localhost:8080/v1/views/leaderboard
+```
+
+```json
+{
+  "rows": [
+    { "player_id": "alice", "total_score": 350 },
+    { "player_id": "bob", "total_score": 200 }
+  ]
+}
+```
+
+**Query parameter filtering:** Add query parameters to filter rows by column values.
+
+```bash
+curl "http://localhost:8080/v1/views/leaderboard?player_id=alice"
+```
+
+```json
+{
+  "rows": [
+    { "player_id": "alice", "total_score": 350 }
+  ]
+}
+```
+
+Multiple parameters are combined with `AND`:
+
+```bash
+curl "http://localhost:8080/v1/views/orders?status=pending&region=us-east"
+```
+
+**Error responses:**
+
+| Status | Body | When |
+|--------|------|------|
+| `404` | `{ "error": "View 'foo' not found", "available": ["leaderboard"], "hint": "..." }` | View does not exist |
+| `401` | `{ "error": "Authentication required..." }` | JWT configured but no valid token |
+
+### Write a single event
+
+```
+POST /v1/streams/{name}
+```
+
+Insert one row into a stream.
+
+```bash
+curl -X POST http://localhost:8080/v1/streams/game_events \
+  -H "Content-Type: application/json" \
+  -d '{"player_id": "alice", "action": "win", "score": 100}'
+```
+
+```json
+{ "ok": true }
+```
+
+**Error responses:**
+
+| Status | Body | When |
+|--------|------|------|
+| `404` | `{ "error": "Stream 'foo' not found", "available": ["game_events"], "hint": "..." }` | Stream does not exist |
+| `400` | `{ "error": "..." }` | Invalid data or insert failure |
+
+### Write a batch of events
+
+```
+POST /v1/streams/{name}/batch
+```
+
+Insert multiple rows in one request. Body must be a JSON array.
+
+```bash
+curl -X POST http://localhost:8080/v1/streams/game_events/batch \
+  -H "Content-Type: application/json" \
+  -d '[
+    {"player_id": "alice", "action": "win", "score": 100},
+    {"player_id": "bob", "action": "loss", "score": -25}
+  ]'
+```
+
+```json
+{ "ok": true }
+```
+
+## Authentication
+
+When JWT is configured, pass the token via the `Authorization` header:
+
+```bash
+curl http://localhost:8080/v1/views/leaderboard \
+  -H "Authorization: Bearer eyJhbG..."
+```
+
+JWT is required for WebSocket subscriptions when configured, but the HTTP API currently accepts requests without a token for view reads and stream writes. JWT filtering only applies to WebSocket diffs.
+
+## CORS
+
+All endpoints return these headers:
+
+```
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, OPTIONS
+Access-Control-Allow-Headers: Content-Type, Authorization
+```
+
+`OPTIONS` requests return `204 No Content`.

--- a/wavelet/server/jwt-auth.mdx
+++ b/wavelet/server/jwt-auth.mdx
@@ -1,0 +1,145 @@
+---
+title: "JWT multi-tenant filtering"
+sidebarTitle: JWT auth
+description: "Wavelet JWT authentication and per-tenant row filtering — configure HS256 or JWKS, use filterBy columns to isolate data per user in real-time subscriptions."
+---
+
+Wavelet uses JWT tokens to filter real-time view diffs per client. A single materialized view can serve multiple tenants — each client only sees rows that match their token claims.
+
+## How it works
+
+1. You define a view with a `filterBy` column
+2. You configure JWT verification (secret or JWKS)
+3. Clients connect with a JWT token
+4. Wavelet extracts the claim matching the `filterBy` column name and filters every diff row
+
+```
+JWT claim: { "tenant_id": "acme" }
+View filterBy: "tenant_id"
+
+→ Client only receives rows where tenant_id = "acme"
+```
+
+## Configuration
+
+### HS256 (shared secret)
+
+```typescript wavelet.config.ts
+export default defineConfig({
+  database: '...',
+
+  jwt: {
+    secret: process.env.JWT_SECRET,
+  },
+
+  views: {
+    tenant_usage: {
+      query: sql`SELECT tenant_id, SUM(cost) AS total FROM events GROUP BY tenant_id`,
+      filterBy: 'tenant_id',
+    },
+  },
+})
+```
+
+### RS256 / JWKS (Auth0, Clerk, etc.)
+
+```typescript wavelet.config.ts
+export default defineConfig({
+  database: '...',
+
+  jwt: {
+    jwksUrl: 'https://your-auth.com/.well-known/jwks.json',
+    issuer: 'https://your-auth.com/',
+    audience: 'your-app-id',
+  },
+
+  views: {
+    my_orders: {
+      query: sql`SELECT * FROM orders`,
+      filterBy: 'customer_id',
+    },
+  },
+})
+```
+
+### JWT config fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `secret` | `string` | HS256 symmetric key |
+| `jwksUrl` | `string` | JWKS endpoint for RS256/ES256 (fetches public keys automatically) |
+| `issuer` | `string` | Expected `iss` claim — rejects tokens from other issuers |
+| `audience` | `string` | Expected `aud` claim — rejects tokens for other apps |
+
+## Client usage
+
+### TypeScript SDK
+
+```typescript
+import { WaveletClient } from '@risingwave/wavelet-sdk'
+
+const client = new WaveletClient({
+  url: 'http://localhost:8080',
+  token: async () => {
+    // Get token from your auth provider
+    const session = await clerk.session
+    return session.getToken()
+  },
+})
+
+// Subscription is automatically filtered by JWT claims
+client.view('tenant_usage').subscribe({
+  onData: (diff) => {
+    // Only receives rows where tenant_id matches the token's tenant_id claim
+    console.log(diff.inserted, diff.updated, diff.deleted)
+  },
+})
+```
+
+### React
+
+```tsx
+import { initWavelet, useWavelet } from '@risingwave/wavelet-sdk/react'
+
+initWavelet({
+  url: 'http://localhost:8080',
+  token: () => getAuthToken(),
+})
+
+function MyOrders() {
+  // Only sees orders for the authenticated customer
+  const { data } = useWavelet('my_orders', { keyBy: 'order_id' })
+  return <OrderList orders={data} />
+}
+```
+
+### Raw WebSocket
+
+Pass the token as a query parameter:
+
+```javascript
+const token = await getAuthToken()
+const ws = new WebSocket(
+  `ws://localhost:8080/subscribe/tenant_usage?token=${encodeURIComponent(token)}`
+)
+```
+
+## Filtering behavior
+
+- **One cursor, many clients.** Wavelet creates a single RisingWave subscription cursor per view. All clients share it. Filtering happens in-memory on the server after fetching from the cursor.
+
+- **Exact string match.** The filter compares `String(row[filterBy])` against `String(claims[filterBy])`. Both sides are converted to strings.
+
+- **No filter = all rows.** If a view does not have `filterBy`, all subscribers receive all diffs regardless of JWT claims.
+
+- **Empty diffs suppressed.** If filtering removes all rows from a diff for a particular client, no message is sent to that client.
+
+## Security notes
+
+- **Server-side enforcement.** Filtering is done on the server. Clients cannot bypass it by modifying WebSocket messages.
+
+- **Token expiry.** Wavelet verifies the token on WebSocket connection. If the token expires mid-session, the connection stays open until disconnected. For strict expiry enforcement, use short-lived tokens and handle reconnection.
+
+- **No JWT = no filtering.** If `jwt` is not configured in your config, WebSocket connections work without tokens and no filtering is applied. The `filterBy` field is ignored.
+
+- **HTTP API.** JWT filtering currently applies only to WebSocket subscriptions. HTTP GET requests to views return unfiltered results (or you can filter manually via query parameters).

--- a/wavelet/server/websocket.mdx
+++ b/wavelet/server/websocket.mdx
@@ -1,0 +1,177 @@
+---
+title: "Wavelet WebSocket protocol"
+sidebarTitle: WebSocket
+description: "Wavelet WebSocket subscription protocol — connection, authentication, diff message format, reconnection, and filtering behavior."
+---
+
+Wavelet pushes real-time diffs to clients over WebSocket. Each connection subscribes to one view and receives incremental changes as they happen in RisingWave.
+
+## Connection
+
+Connect to:
+
+```
+ws://localhost:8080/subscribe/{viewName}
+```
+
+With JWT authentication:
+
+```
+ws://localhost:8080/subscribe/{viewName}?token={jwt}
+```
+
+Or use the `Authorization` header (if your WebSocket client supports it):
+
+```
+Authorization: Bearer {jwt}
+```
+
+## Message flow
+
+### 1. Connected
+
+After a successful connection, the server sends:
+
+```json
+{
+  "type": "connected",
+  "view": "leaderboard"
+}
+```
+
+### 2. Diffs
+
+As the materialized view changes, the server sends diff messages:
+
+```json
+{
+  "type": "diff",
+  "view": "leaderboard",
+  "cursor": "1711234567890",
+  "inserted": [
+    { "player_id": "charlie", "total_score": 50 }
+  ],
+  "updated": [
+    { "player_id": "alice", "total_score": 400 }
+  ],
+  "deleted": [
+    { "player_id": "old_player", "total_score": 10 }
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `"diff"` | Message type discriminator |
+| `view` | `string` | View name |
+| `cursor` | `string` | RisingWave timestamp of this change |
+| `inserted` | `object[]` | New rows added to the view |
+| `updated` | `object[]` | Rows whose values changed (new values) |
+| `deleted` | `object[]` | Rows removed from the view |
+
+<Note>
+Empty diffs are never sent. If a change in the underlying data does not affect the view result, no message is pushed.
+</Note>
+
+### Op code mapping
+
+Wavelet translates RisingWave's subscription op codes into the three diff categories:
+
+| RisingWave op | Meaning | Diff field |
+|---------------|---------|------------|
+| `1` / `Insert` | New row | `inserted` |
+| `2` / `Delete` | Row removed | `deleted` |
+| `3` / `UpdateDelete` | Old value before update | `deleted` |
+| `4` / `UpdateInsert` | New value after update | `updated` |
+
+The `op` and `rw_timestamp` columns are stripped from the row data before sending to clients.
+
+## JWT filtering
+
+When a view has a `filterBy` column and the client connects with a JWT token, diffs are filtered per-client:
+
+1. Server extracts claims from the JWT
+2. For each row in a diff, it checks: `row[filterBy] === String(claims[filterBy])`
+3. Only matching rows are sent to that client
+
+This means all clients share a single RisingWave cursor, but each receives only the rows they are authorized to see.
+
+```
+                ┌─ Client A (tenant_id=t1) ──▶ only t1 rows
+Cursor ────────┤
+                └─ Client B (tenant_id=t2) ──▶ only t2 rows
+```
+
+If a diff has no matching rows for a client after filtering, no message is sent.
+
+## Reconnection
+
+The Wavelet SDK handles reconnection automatically with exponential backoff:
+
+```
+Disconnect → wait 1s → reconnect → wait 2s → reconnect → wait 4s → ... (max 30s)
+```
+
+On reconnect, the SDK passes the last received `cursor` value:
+
+```
+ws://localhost:8080/subscribe/leaderboard?cursor={lastCursor}
+```
+
+This allows the server to resume from where the client left off (within RisingWave's 24-hour retention window).
+
+### Close codes
+
+| Code | Meaning | SDK behavior |
+|------|---------|-------------|
+| Normal close | Server shutdown or client disconnect | Reconnect with backoff |
+| `4000` | Auth rejected (invalid token, view not found) | **No reconnect.** Calls `onError`. |
+
+## Cursor mechanism
+
+Under the hood, Wavelet uses RisingWave's native subscription cursor:
+
+```sql
+-- Server creates a subscription for each view
+CREATE SUBSCRIPTION wavelet_sub_leaderboard FROM leaderboard WITH (retention = '24h');
+
+-- Server opens a blocking cursor
+DECLARE cursor_123 SUBSCRIPTION CURSOR FOR wavelet_sub_leaderboard;
+
+-- Server fetches changes (blocks until data or 5s timeout)
+FETCH NEXT FROM cursor_123 WITH (timeout = '5s');
+```
+
+Each view has **one cursor** shared across all WebSocket clients. The server fans out diffs from that single cursor to all subscribers, applying per-client JWT filtering as needed.
+
+This design means:
+- Adding more WebSocket clients does not create more database cursors
+- Latency is bounded by the 5-second fetch timeout (typically sub-second for active views)
+- On server restart, cursors recover from RisingWave's 24-hour retention window
+
+## Example: vanilla JavaScript
+
+```javascript
+const ws = new WebSocket('ws://localhost:8080/subscribe/leaderboard')
+
+const state = new Map()
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data)
+
+  if (msg.type === 'connected') {
+    console.log('Connected to', msg.view)
+    return
+  }
+
+  if (msg.type === 'diff') {
+    for (const row of msg.deleted) {
+      state.delete(row.player_id)
+    }
+    for (const row of [...msg.inserted, ...msg.updated]) {
+      state.set(row.player_id, row)
+    }
+    renderLeaderboard(Array.from(state.values()))
+  }
+}
+```

--- a/wavelet/sources/postgres-cdc.mdx
+++ b/wavelet/sources/postgres-cdc.mdx
@@ -1,0 +1,172 @@
+---
+title: "Postgres CDC source"
+sidebarTitle: Postgres CDC
+description: "Ingest data from existing PostgreSQL databases into Wavelet via Change Data Capture. Real-time replication from Postgres tables into RisingWave materialized views."
+---
+
+Wavelet can ingest data from existing PostgreSQL databases via CDC (Change Data Capture). Changes in your Postgres tables — inserts, updates, deletes — automatically flow into RisingWave, where they can be referenced in view queries.
+
+## Prerequisites
+
+Your source PostgreSQL database must have:
+
+- **`wal_level = logical`** — required for logical replication
+- **A user with replication privileges** — `ALTER ROLE myuser REPLICATION;`
+- **Primary keys on all captured tables** — RisingWave requires this for CDC
+
+<Tip>
+Most managed Postgres services (AWS RDS, Supabase, Neon) support logical replication but may require enabling it in settings. Check your provider's docs.
+</Tip>
+
+## Configuration
+
+```typescript wavelet.config.ts
+import { defineConfig, sql } from '@risingwave/wavelet'
+
+export default defineConfig({
+  database: 'postgresql://root@localhost:4566/dev',
+
+  sources: {
+    app_db: {
+      type: 'postgres',
+      connection: 'postgresql://user:password@db.example.com:5432/myapp',
+      tables: ['users', 'orders', 'products'],
+    },
+  },
+
+  views: {
+    order_summary: {
+      query: sql`
+        SELECT
+          u.name AS customer_name,
+          COUNT(o.id) AS order_count,
+          SUM(o.total) AS total_spent
+        FROM app_db_users u
+        JOIN app_db_orders o ON u.id = o.user_id
+        GROUP BY u.name
+      `,
+    },
+  },
+})
+```
+
+### Source fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `'postgres'` | Yes | — | Source type (only Postgres supported currently) |
+| `connection` | `string` | Yes | — | PostgreSQL connection URL |
+| `tables` | `string[]` | Yes | — | Tables to capture via CDC |
+| `slotName` | `string` | No | `wavelet_{sourceName}` | Logical replication slot name |
+| `publicationName` | `string` | No | `wavelet_{sourceName}_pub` | Publication name |
+
+## Table naming
+
+CDC tables in RisingWave are named `{sourceName}_{tableName}`:
+
+| Source name | Postgres table | RisingWave table |
+|-------------|---------------|-----------------|
+| `app_db` | `users` | `app_db_users` |
+| `app_db` | `orders` | `app_db_orders` |
+| `main` | `products` | `main_products` |
+
+Use these names when referencing CDC tables in view queries.
+
+## Generated DDL
+
+For each table, Wavelet generates a RisingWave `CREATE TABLE` with the CDC connector:
+
+```sql
+CREATE TABLE IF NOT EXISTS app_db_users (*)
+WITH (
+  connector = 'postgres-cdc',
+  hostname = 'db.example.com',
+  port = '5432',
+  username = 'user',
+  password = 'password',
+  database.name = 'myapp',
+  schema.name = 'public',
+  table.name = 'users',
+  slot.name = 'wavelet_app_db',
+  publication.name = 'wavelet_app_db_pub'
+);
+```
+
+The `(*)` syntax tells RisingWave to automatically detect the table's columns from the source. The connection string is parsed to extract hostname, port, credentials, and database name.
+
+## Schema support
+
+By default, tables are read from the `public` schema. To specify a different schema, add it as a query parameter in the connection string:
+
+```typescript
+sources: {
+  app_db: {
+    type: 'postgres',
+    connection: 'postgresql://user:pass@host:5432/mydb?schema=inventory',
+    tables: ['items', 'warehouses'],
+  },
+}
+```
+
+## Replication slot and publication
+
+Wavelet auto-generates names for the replication slot and publication based on the source name. You can override them if needed:
+
+```typescript
+sources: {
+  app_db: {
+    type: 'postgres',
+    connection: 'postgresql://user:pass@host:5432/mydb',
+    tables: ['users'],
+    slotName: 'my_custom_slot',
+    publicationName: 'my_custom_publication',
+  },
+}
+```
+
+<Warning>
+Replication slots consume WAL on the source Postgres. If RisingWave is down for an extended period, the slot will retain WAL and may fill up your disk. Monitor your source database's replication lag.
+</Warning>
+
+## Combining CDC sources with streams
+
+You can combine CDC data from existing databases with Wavelet streams (HTTP writes) in the same view:
+
+```typescript
+export default defineConfig({
+  database: 'postgresql://root@localhost:4566/dev',
+
+  sources: {
+    app_db: {
+      type: 'postgres',
+      connection: process.env.APP_DATABASE_URL!,
+      tables: ['users'],
+    },
+  },
+
+  streams: {
+    click_events: {
+      columns: {
+        user_id: 'int',
+        page: 'string',
+        clicked_at: 'timestamp',
+      },
+    },
+  },
+
+  views: {
+    user_activity: {
+      query: sql`
+        SELECT
+          u.id AS user_id,
+          u.name,
+          COUNT(c.page) AS total_clicks
+        FROM app_db_users u
+        LEFT JOIN click_events c ON u.id = c.user_id
+        GROUP BY u.id, u.name
+      `,
+      keyBy: 'user_id',
+    },
+  },
+})
+```


### PR DESCRIPTION
Add comprehensive Wavelet documentation as a new top-level tab in the RisingWave docs site. Includes: overview, getting started guide, config reference, CLI reference, TypeScript SDK, React hooks, HTTP API, WebSocket protocol, JWT multi-tenant filtering, Postgres CDC sources, codegen, and MCP AI agent integration.

## Description

[ Please provide a brief summary of the documentation changes and purpose. ]

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `mint.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
