### PR TITLE
docs(cloud): add dedicated rwc CLI setup page, align with prod-mode GA

### DIFF
--- a/cloud/install-cli.mdx
+++ b/cloud/install-cli.mdx
@@ -1,0 +1,99 @@
+---
+title: "Install the RisingWave Cloud CLI"
+description: "Install and configure `rwc`, the command-line interface for RisingWave Cloud. Use it to manage hosted, BYOC, and BYOK environments, clusters, database users, snapshots, and more."
+---
+
+`rwc` is the RisingWave Cloud CLI. Use it to manage hosted, [BYOC](/cloud/project-byoc), and BYOK environments, clusters, database users, connection endpoints, and snapshots from your terminal or CI pipeline.
+
+## Step 1: Install the binary
+
+Download and install the latest release:
+
+```bash
+curl -L https://rwc-cli-internal-release.s3.ap-southeast-1.amazonaws.com/download.sh | bash && sudo mv rwc /usr/local/bin
+```
+
+Verify the install:
+
+```bash
+rwc version
+rwc -h
+```
+
+## Step 2: Authenticate
+
+Choose one of the following methods, depending on how your RisingWave Cloud account was created.
+
+<Tabs>
+<Tab title="API key (recommended)">
+1. Generate an API key and secret from the **RisingWave Cloud console** (under your account settings).
+2. Configure the CLI:
+
+   ```bash
+   rwc auth config --api-key '<api-key>' --api-key-secret '<api-key-secret>'
+   ```
+</Tab>
+<Tab title="Email and password">
+Only accounts registered with an email and password can use this method. Accounts created via social login (Google, Microsoft, or GitHub) do not support username/password login — use **API key** instead.
+
+```bash
+rwc auth login --account '<your-email@example.com>' --password '<your-password>'
+```
+
+To register a new password account first, then log in:
+
+```bash
+rwc auth register --account '<your-email@example.com>' --password '<your-password>'
+rwc auth login    --account '<your-email@example.com>' --password '<your-password>'
+```
+</Tab>
+</Tabs>
+
+## Step 3: Select a region
+
+List the regions available to your account, then set the active one:
+
+```bash
+rwc context region list
+rwc context region set --name <region-name>
+```
+
+Example region names include `us-east-1`, `us-west-2`, and `eu-west-1` — use `rwc context region list` to see the exact set available to you.
+
+## Step 4: Verify the setup
+
+Confirm that authentication and region are wired up end-to-end:
+
+```bash
+rwc context list          # shows account URL, region, and auth method
+rwc cluster list          # returns your clusters (or an empty list)
+```
+
+If `rwc cluster list` returns without an authentication or configuration error, your CLI is ready to use.
+
+## (Optional) Install agent skills
+
+`rwc` ships with embedded agent skills (documentation modules describing each command domain) that you can install into your AI coding assistant's configuration directory. This lets Claude Code, Cursor, Codex, and similar tools answer `rwc` questions accurately and route requests to the right subcommand.
+
+```bash
+rwc skill list                                # list available skills
+rwc skill show <skill-name>                   # print a skill to stdout
+rwc skill install --target claude-code        # install into the current project
+rwc skill install --target claude-code --global  # install into ~/.claude
+```
+
+Supported targets include `claude-code`, `cursor`, and `codex`.
+
+## Common issues
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `unauthorized` on `rwc auth login` | Account was created via Google/GitHub/Microsoft social login | Generate an API key from the console and use `rwc auth config` instead |
+| `unauthorized` after working setup | Expired token | Re-run Step 2 |
+| `region not found` | Region name typo, or region not enabled for your account | Run `rwc context region list` and use one of the listed names |
+| `mgmt URL is not configured` on any command | Region has not been selected yet | Run `rwc context region set --name <region>` |
+| Command works locally but fails in CI | CI environment is missing `~/.rwc/config` | Run `rwc auth config` with an API key inside the CI job |
+
+## Next steps
+
+- Run `rwc -h` or `rwc <command> -h` to see the authoritative flag list for any subcommand.

--- a/cloud/install-cli.mdx
+++ b/cloud/install-cli.mdx
@@ -26,28 +26,12 @@ Choose one of the following methods, depending on how your RisingWave Cloud acco
 
 <Tabs>
 <Tab title="API key (recommended)">
-1. Generate an API key and secret from the **RisingWave Cloud console** (under your account settings).
-2. Configure the CLI:
+  <Tab title="API key (recommended)">
 
-   ```bash
-   rwc auth config --api-key '<api-key>' --api-key-secret '<api-key-secret>'
-   ```
-</Tab>
-<Tab title="Email and password">
-Only accounts registered with an email and password can use this method. Accounts created via social login (Google, Microsoft, or GitHub) do not support username/password login — use **API key** instead.
+  1. Generate an API key and secret from the **RisingWave Cloud console** (under your account settings).
+  2. Configure the CLI:
 
-```bash
-rwc auth login --account '<your-email@example.com>' --password '<your-password>'
-```
-
-To register a new password account first, then log in:
-
-```bash
-rwc auth register --account '<your-email@example.com>' --password '<your-password>'
-# Check your inbox and click the magic link to activate the account before logging in.
-rwc auth login    --account '<your-email@example.com>' --password '<your-password>'
-```
-</Tab>
+     
 </Tabs>
 
 ## Step 3: Select a region

--- a/cloud/install-cli.mdx
+++ b/cloud/install-cli.mdx
@@ -25,13 +25,31 @@ rwc -h
 Choose one of the following methods, depending on how your RisingWave Cloud account was created.
 
 <Tabs>
-<Tab title="API key (recommended)">
   <Tab title="API key (recommended)">
 
-  1. Generate an API key and secret from the **RisingWave Cloud console** (under your account settings).
+  1. Generate an API key and secret from the **RisingWave Cloud console** under **Org → Service accounts**. See [Service account & API key](/cloud/service-account) for details.
   2. Configure the CLI:
 
-     
+     ```bash
+     rwc auth config --api-key '<api-key>' --api-key-secret '<api-key-secret>'
+     ```
+  </Tab>
+  <Tab title="Email and password">
+
+  Only accounts registered with an email and password can use this method. Accounts created via social login (Google, Microsoft, or GitHub) do not support username/password login — use **API key** instead.
+
+  ```bash
+  rwc auth login --account '<your-email@example.com>' --password '<your-password>'
+  ```
+
+  To register a new password account first, then log in:
+
+  ```bash
+  rwc auth register --account '<your-email@example.com>' --password '<your-password>'
+  # Check your inbox and click the magic link to activate the account before logging in.
+  rwc auth login    --account '<your-email@example.com>' --password '<your-password>'
+  ```
+  </Tab>
 </Tabs>
 
 ## Step 3: Select a region
@@ -82,3 +100,4 @@ Supported targets include `claude-code`, `cursor`, and `codex`.
 ## Next steps
 
 - Run `rwc -h` or `rwc <command> -h` to see the authoritative flag list for any subcommand.
+- Set up a [BYOC environment](/cloud/project-byoc) using your new CLI.

--- a/cloud/install-cli.mdx
+++ b/cloud/install-cli.mdx
@@ -44,6 +44,7 @@ To register a new password account first, then log in:
 
 ```bash
 rwc auth register --account '<your-email@example.com>' --password '<your-password>'
+# Check your inbox and click the magic link to activate the account before logging in.
 rwc auth login    --account '<your-email@example.com>' --password '<your-password>'
 ```
 </Tab>

--- a/cloud/project-byoc.mdx
+++ b/cloud/project-byoc.mdx
@@ -12,28 +12,11 @@ Before creating a BYOC deployment, familiarize yourself with the following archi
 * **Agent Service**: This service manages Kubernetes (K8s) and cloud resources. It handles tasks such as managing RisingWave Pods, storage services (including AWS S3, GCS, and Azure Blob Storage), IAM roles/accounts associated with the RisingWave cluster, network endpoints, etc.
 * **RWProxy**: This is a TCP proxy that routes SQL statements from the control plane to the appropriate RisingWave instances. Control plane will issue SQL queries to retrieve cluster metadata and health status.
 
-## Install and configure `rwc`
+## Prerequisites
 
-Follow the steps below to install `rwc` (RisingWave Cloud CLI) and configure it for your environment.
+BYOC uses the `rwc` (RisingWave Cloud CLI) to provision and manage environments. Before continuing, install and authenticate the CLI by following [Install the RisingWave Cloud CLI](/cloud/install-cli).
 
-1. Run the following command to download and install the CLI tool:
-
-   ```
-   curl -L https://rwc-cli-internal-release.s3.ap-southeast-1.amazonaws.com/download.sh | bash && sudo mv rwc /usr/local/bin
-   ```
-
-2. After installation, open your terminal and execute the following commands to connect to the production environment and log in to your account.
-
-   ```
-   # Connect to the production environment
-   rwc context account set --url https://canary-useast2-acc.risingwave.cloud/api/v1
-   rwc context region set --name us-east-1
-    
-   # Login to RisingWave Cloud
-   rwc auth login --account '<your name>@mock.mail' --password '<your password>'  
-   ```
-
-Once these steps are complete, your CLI environment is ready. You can now proceed to create your BYOC environment.
+Once `rwc cluster list` runs successfully in your chosen region, you are ready to create a BYOC environment.
 
 ## Create a BYOC environment
 
@@ -133,7 +116,7 @@ You may either create a new BYOC environment or update your existing one to appl
 
 <Tabs>
   <Tab title="Create a new BYOC environment">
-    1. Run the following command to create a new BYOC environment with custom settings. `$BYOC_CONFG` is the file path of the config file created in last step.
+    1. Run the following command to create a new BYOC environment with custom settings. `$BYOC_CONFIG` is the file path of the config file created in last step.
 
 ```bash
 $ rwc byoc create \

--- a/cloud/project-byoc.mdx
+++ b/cloud/project-byoc.mdx
@@ -116,7 +116,7 @@ You may either create a new BYOC environment or update your existing one to appl
 
 <Tabs>
   <Tab title="Create a new BYOC environment">
-    1. Run the following command to create a new BYOC environment with custom settings. `$BYOC_CONFIG` is the file path of the config file created in last step.
+    1. Run the following command to create a new BYOC environment with custom settings. `$BYOC_CONFIG` is the file path of the config file created in the previous step.
 
 ```bash
 $ rwc byoc create \

--- a/docs.json
+++ b/docs.json
@@ -515,7 +515,8 @@
                     "group": "Get started",
                     "pages": [
                       "cloud/quickstart",
-                      "cloud/signup-login"
+                      "cloud/signup-login",
+                      "cloud/install-cli"
                     ]
                   },
                   {

--- a/reference/key-concepts.mdx
+++ b/reference/key-concepts.mdx
@@ -106,7 +106,7 @@ For a web-based interface to manage and monitor your RisingWave clusters, you ca
 
 ## `rwc`
 
-`rwc` (RisingWave Cloud CLI) is a command-line tool for accessing and managing RisingWave Cloud/BYOC instances via open APIs. It is particularly useful for [setting up the BYOC cluster](/cloud/project-byoc#create-a-byoc-environment). For more information, please refer to [this document](https://github.com/risingwavelabs/risingwave-cloud/blob/main/cli/README.md#installation).
+`rwc` (RisingWave Cloud CLI) is a command-line tool for accessing and managing RisingWave Cloud/BYOC instances via open APIs. It is particularly useful for [setting up the BYOC cluster](/cloud/project-byoc#create-a-byoc-environment). For installation and setup instructions, see [Install the RisingWave Cloud CLI](/cloud/install-cli).
 
 ## Serialization
 


### PR DESCRIPTION
## Summary

Extract the \`rwc\` install / auth / region-setup steps out of the BYOC page and promote them to a **standalone page under Cloud → Get started**, so users who aren't doing BYOC can still discover and use the CLI. Refresh the flow to match the GA work landing under [CLOUD-4736](https://linear.app/risingwave-labs/issue/CLOUD-4736/ga-the-rwc-cli).

- **New page** [\`cloud/install-cli.mdx\`](cloud/install-cli.mdx) — 4-step setup (install → authenticate → select region → verify) + optional \`rwc skill install\` section + common-issues table.
- **BYOC page** trimmed: the old *Install and configure \`rwc\`* section is replaced by a short Prerequisites note linking to the new page. Keeps BYOC-specific content only.
- **Nav**: registered \`cloud/install-cli\` in the *Cloud → Get started* group in \`docs.json\`.

## Why the existing docs were off

The old install section under [\`cloud/project-byoc.mdx\`](cloud/project-byoc.mdx) was the **only** place \`rwc\` was documented, and it had several issues:

| Old content | Problem |
|---|---|
| \`rwc context account set --url https://canary-useast2-acc.risingwave.cloud/api/v1\` | Asks users to configure an internal canary URL. Unnecessary after CLOUD-4737 — released binaries default to the production account URL. |
| \`rwc auth login --account '<your name>@mock.mail' --password '<your password>'\` | \`mock.mail\` is an internal placeholder; login doesn't work for social-login accounts; API key method wasn't mentioned. |
| Hardcoded \`rwc context region set --name us-east-1\` | No step telling users how to list the regions their account actually has. |
| No BYOC/non-BYOC split | Non-BYOC CLI users had no landing page. |
| \`$BYOC_CONFG\` typo | Minor, fixed in passing. |

## Alignment with the CLI GA changes

| Upstream change | Doc impact |
|---|---|
| [risingwavelabs/risingwave-cloud#13979](https://github.com/risingwavelabs/risingwave-cloud/pull/13979) — release pipeline switched to prod mode; \`ProductionURL\` → canary-useast2 | Drop \`rwc context account set --url ...\` from setup flow. |
| [risingwavelabs/risingwave-cloud#14035](https://github.com/risingwavelabs/risingwave-cloud/pull/14035) — empty defaults in prod; \`NewMgmtClient\` surfaces clear error when region isn't set | Common-issues table covers the new \`mgmt URL is not configured\` error and points at \`rwc context region set\`. |
| [risingwavelabs/risingwave-cloud#13988](https://github.com/risingwavelabs/risingwave-cloud/pull/13988) — \`rwc skill\` subcommand (list / show / install) with embedded agent skills | New *(Optional) Install agent skills* section documents \`rwc skill install --target claude-code [--global]\`. |

## Files changed

- \`cloud/install-cli.mdx\` — new
- \`cloud/project-byoc.mdx\` — drop install section, add prereq link, fix \`\$BYOC_CONFG\` typo
- \`docs.json\` — nav entry

## Test plan

- [ ] Preview the docs site and confirm the new page renders under **Cloud → Get started** between *Sign up and log in* and *Projects*.
- [ ] Verify the Tabs component renders both **API key** and **Email and password** tabs.
- [ ] Confirm the internal link from \`cloud/project-byoc.mdx\` *Prerequisites* → \`/cloud/install-cli\` resolves.
- [ ] Confirm the *Next steps* link on the new page → \`/cloud/project-byoc\` resolves.
- [ ] Spot-check the install, \`rwc auth config\`, and \`rwc context region set\` commands against a fresh \`rwc\` install built from \`origin/main\` of \`risingwave-cloud\`.

## Follow-ups (out of scope for this PR)

- Full \`rwc\` command reference (cluster / context / snapshot / byok) — not blocking GA docs; the embedded skills (\`rwc skill\`) already cover this for AI-assistant users.
- Replace the \`rwc-cli-internal-release\` S3 download URL with the final public release URL once available.