### PR TITLE
fix(workflow): use GitHub App installation token for Copilot assignment

### DIFF
--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -55,9 +55,10 @@ jobs:
           http=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $COPILOT_TOKEN" \
+            -H "Content-Type: application/json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees" \
-            -d "$body") || {
+            --data-binary "$body") || {
             echo "::error::curl failed (transport error)"
             exit 1
           }

--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -12,21 +12,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COPILOT_APP_ID }}
+          private-key: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
+
       - name: Assign issue to Copilot via REST API
         env:
-          COPILOT_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          COPILOT_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          # Strip any accidental whitespace/newlines from the token value
-          COPILOT_TOKEN="$(printf '%s' "$COPILOT_TOKEN" | tr -d '[:space:]')"
-
-          if [ -z "$COPILOT_TOKEN" ]; then
-            echo "Missing COPILOT_ASSIGN_TOKEN secret."
-            exit 1
-          fi
-
           http=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $COPILOT_TOKEN" \

--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -19,25 +19,22 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # Strip any accidental whitespace/newlines from the token value
+          COPILOT_TOKEN="$(printf '%s' "$COPILOT_TOKEN" | tr -d '[:space:]')"
+
           if [ -z "$COPILOT_TOKEN" ]; then
             echo "Missing COPILOT_ASSIGN_TOKEN secret."
             exit 1
           fi
 
-          cat <<JSON | curl -sS -X POST \
+          http=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $COPILOT_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees" \
-            -d @-
-          {
-            "assignees": ["copilot-swe-agent[bot]"],
-            "agent_assignment": {
-              "target_repo": "${REPO}",
-              "base_branch": "${BASE_BRANCH}",
-              "custom_instructions": "",
-              "custom_agent": "",
-              "model": ""
-            }
-          }
-          JSON
+            -d "{\"assignees\":[\"copilot-swe-agent[bot]\"],\"agent_assignment\":{\"target_repo\":\"$REPO\",\"base_branch\":\"$BASE_BRANCH\",\"custom_instructions\":\"\",\"custom_agent\":\"\",\"model\":\"\"}}")
+
+          echo "HTTP $http"
+          cat /tmp/resp.json
+
+          [ "$http" -ge 200 ] && [ "$http" -lt 300 ]

--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -12,6 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate secrets
+        env:
+          APP_ID: ${{ secrets.COPILOT_APP_ID }}
+          APP_KEY: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$APP_ID" ] || [ -z "$APP_KEY" ]; then
+            echo "::error::Missing required secrets: COPILOT_APP_ID and/or COPILOT_APP_PRIVATE_KEY"
+            exit 1
+          fi
+
       - name: Generate GitHub App installation token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -26,14 +36,36 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          set -euo pipefail
+
+          body=$(jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BASE_BRANCH" \
+            '{
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $repo,
+                base_branch: $branch,
+                custom_instructions: "",
+                custom_agent: "",
+                model: ""
+              }
+            }')
+
           http=$(curl -sS -o /tmp/resp.json -w '%{http_code}' -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $COPILOT_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees" \
-            -d "{\"assignees\":[\"copilot-swe-agent[bot]\"],\"agent_assignment\":{\"target_repo\":\"$REPO\",\"base_branch\":\"$BASE_BRANCH\",\"custom_instructions\":\"\",\"custom_agent\":\"\",\"model\":\"\"}}")
+            -d "$body") || {
+            echo "::error::curl failed (transport error)"
+            exit 1
+          }
 
           echo "HTTP $http"
-          cat /tmp/resp.json
+          [ -f /tmp/resp.json ] && cat /tmp/resp.json
 
-          [ "$http" -ge 200 ] && [ "$http" -lt 300 ]
+          if [ "$http" -lt 200 ] || [ "$http" -ge 300 ]; then
+            echo "::error::API returned HTTP $http"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

The `auto-assign-issues-to-copilot.yml` workflow was broken because:

1. **Wrong token type**: The secret `COPILOT_ASSIGN_TOKEN` contained a GitHub App PEM private key, not a Bearer token. PEM keys can't be used directly as Authorization headers — they must be exchanged for a short-lived installation token first.
2. **Silent failures**: `curl -sS` without `-f` means HTTP 401/403 responses appeared as `conclusion: success` in GitHub Actions, making failures invisible.
3. **Heredoc terminator indentation**: The `<<JSON` heredoc had its terminator indented, which bash never recognizes as the end — causing malformed request bodies.

## Changes

- **Switch to `actions/create-github-app-token@v1`**: Uses `COPILOT_APP_ID` + `COPILOT_APP_PRIVATE_KEY` (PEM) to generate a short-lived installation token at runtime — the correct way to authenticate as a GitHub App.
- **Explicit secret validation**: Fail early with a clear error if either secret is missing.
- **`jq -n` for JSON body**: Cleaner than escaped inline strings, easier to maintain.
- **`set -euo pipefail`** + curl error handling: Transport failures exit non-zero with a clear message.
- **HTTP status surfacing**: Capture status code with `-w '%{http_code}'` and print response body, exit non-zero on non-2xx.

## Before merging

Store these two secrets in the repo:
```bash
gh secret set COPILOT_APP_ID --repo risingwavelabs/risingwave-docs --body '<App ID number>'
gh secret set COPILOT_APP_PRIVATE_KEY --repo risingwavelabs/risingwave-docs --body "$(cat /path/to/app.pem)"
```

App ID is visible on the RW Jarvis Bot settings page in the org.

## After merging

- Re-run workflows for unassigned issues: #1118, #1115, #1114, #1109
- Delete the old `COPILOT_ASSIGN_TOKEN` secret (no longer used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)