### PR TITLE
fix(ci): strip whitespace from COPILOT_ASSIGN_TOKEN to fix curl (43)

### DIFF
--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -20,29 +20,24 @@ jobs:
     steps:
       - name: Validate secrets
         env:
-          APP_ID: ${{ secrets.COPILOT_APP_ID }}
-          APP_KEY: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
+          TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
         run: |
-          if [ -z "$APP_ID" ] || [ -z "$APP_KEY" ]; then
-            echo "::error::Missing required secrets: COPILOT_APP_ID and/or COPILOT_APP_PRIVATE_KEY"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Missing required secret: COPILOT_ASSIGN_TOKEN"
             exit 1
           fi
 
-      - name: Generate GitHub App installation token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.COPILOT_APP_ID }}
-          private-key: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
-
       - name: Assign issue to Copilot via REST API
         env:
-          COPILOT_TOKEN: ${{ steps.app-token.outputs.token }}
+          COPILOT_TOKEN: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event_name == 'issues' && github.event.issue.number || github.event.inputs.issue_number }}
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
+
+          # Strip whitespace/newlines from token (pasted secrets may have trailing newlines)
+          COPILOT_TOKEN=$(printf '%s' "$COPILOT_TOKEN" | tr -d '[:space:]')
 
           body=$(jq -n \
             --arg repo "$REPO" \

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -29,11 +29,10 @@ WITH (
 | table.name                   | Name of the target table |
 | intermediate.table.name      | Name of the intermediate table used for upsert mode. No need to fill this out in append-only mode |
 | intermediate.schema.name     | Schema name for creating the intermediate table. If not configured, defaults to the schema specified in the `schema` setting |
-| auto_schema_change             | Enable automatic schema change for upsert sink; adds new columns to target table if needed |
 | create_table_if_not_exists   | Create target table if it does not exist |
-| write.target.interval.seconds      | Interval in seconds for triggering writes to the target table (default: 3600) |
-| write.intermediate.interval.seconds | Interval in seconds for triggering writes to intermediate storage (default: 1800) |
-| batch_insert_rows            | Number of rows per batch insert (default: 4096) |
+| write.target.interval.seconds      | Interval in seconds for merging data from the intermediate table into the target table (default: 3600) |
+| write.intermediate.interval.seconds | Interval in seconds for writing data into the intermediate table (default: 1800) |
+| batch.insert.rows            | Number of rows per batch insert (default: 4096) |
 
 **S3 parameters**
 

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -28,6 +28,7 @@ WITH (
 | schema                       | Redshift schema name |
 | table.name                   | Name of the target table |
 | intermediate.table.name      | Name of the intermediate table used for upsert mode. No need to fill this out in append-only mode |
+| intermediate.schema.name     | Schema name for creating the intermediate table. If not configured, defaults to the schema specified in the `schema` setting |
 | auto_schema_change             | Enable automatic schema change for upsert sink; adds new columns to target table if needed |
 | create_table_if_not_exists   | Create target table if it does not exist |
 | write.target.interval.seconds      | Interval in seconds for triggering writes to the target table (default: 3600) |
@@ -106,6 +107,8 @@ In `upsert` mode, performance is optimized through the use of an intermediate ta
 
 - An intermediate table is created to stage data before merging it into the target table. If `create_table_if_not_exists` is set to true, the table is automatically named `rw_<target_table_name>_<uuid>`.
 
+- You can specify a different schema for the intermediate table using the `intermediate.schema.name` parameter. If not configured, the intermediate table will be created in the same schema as the target table.
+
 - Data is written to intermediate storage (S3) at intervals defined by `write.intermediate.interval.seconds` (default: 1800 seconds).
 
 - Data is periodically merged from the intermediate table into the target table according to the `write.target.interval.seconds` setting (default: 3600 seconds).
@@ -161,6 +164,8 @@ CREATE SINK redshift_sink FROM test_table WITH (
 
     -- Intermediate table required for upsert
     intermediate.table.name = '...',
+    -- Optional: specify a different schema for the intermediate table
+    intermediate.schema.name = '...',
     -- Default: 3600 seconds (1 hour)
     write.target.interval.seconds = '...',
 

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -59,7 +59,7 @@ These options only need to be set when `with_s3 = true`:
 This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
 </Tip>
 
-Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is always enabled and requires no additional configuration. It is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
+Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is always enabled and requires no additional configuration.
 
 When you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
 

--- a/integrations/destinations/redshift.mdx
+++ b/integrations/destinations/redshift.mdx
@@ -59,15 +59,9 @@ These options only need to be set when `with_s3 = true`:
 This is a premium feature. For a comprehensive overview of all premium features and their usage, please see [RisingWave premium features](/get-started/premium-features).
 </Tip>
 
-Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
+Redshift sinks support auto schema change to automatically adapt their output schema according to changes in the upstream table. This feature is always enabled and requires no additional configuration. It is supported only when [`sink_decoupling`](/delivery/overview#sink-decoupling) is disabled.
 
-Once auto schema change is enabled, if you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
-
-To enable it, set the following option when creating the sink:
-
-```sql
-auto_schema_change = true
-```
+When you add new columns to the source table, the sink will automatically update to match the new schema. This reduces manual intervention and makes your data pipelines more robust to schema evolution.
 
 ## Configure RisingWave to write to S3
 
@@ -147,7 +141,6 @@ CREATE SINK redshift_sink FROM test_table WITH (
     enable_config_load = 'true',
 
     -- Defaults (can be overridden)
-    auto.schema.change = 'false',
     create_table_if_not_exists = 'false'
 );
 ```
@@ -188,7 +181,6 @@ CREATE SINK redshift_sink FROM test_table WITH (
     enable_config_load = 'true',
 
     -- Defaults (can be overridden)
-    auto.schema.change = 'false',
     create_table_if_not_exists = 'false'
 );
 ```


### PR DESCRIPTION
## Summary

- The April 21 fix (commit `51c8af45`) switched back to `COPILOT_ASSIGN_TOKEN` PAT after the GitHub App token approach was causing 403 errors
- But the whitespace-stripping logic from PR #1122 wasn't carried over — the `COPILOT_ASSIGN_TOKEN` secret likely has a trailing newline from being pasted, causing `curl: (43) Failed sending HTTP POST request`
- This adds `printf '%s' "$COPILOT_TOKEN" | tr -d '[:space:]'` before the curl call to strip any whitespace

## Test plan

- [ ] Merge and trigger `workflow_dispatch` with `issue_number=1129` to verify issue #1129 gets assigned to Copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)