### PR TITLE
feat(ci): auto-request source PR author as reviewer on docs PRs

### DIFF
--- a/.github/workflows/request-source-author-review.yml
+++ b/.github/workflows/request-source-author-review.yml
@@ -22,8 +22,9 @@ jobs:
           set -euo pipefail
 
           # Extract linked issue number from PR body.
-          # Handles: "Closes #N", "Fixes: #N", "Resolves #N", full issue URLs, etc.
-          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oiP '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:#\K\d+|https://github\.com/[^[:space:]]+/issues/\K\d+)' | head -1 || true)
+          # Handles: "Closes #N", "Fixes: #N", "Resolves #N", and full issue URLs for this repository.
+          REPO_REGEX=$(printf '%s\n' "$REPO" | sed 's/[][(){}.^$*+?|\\/]/\\&/g')
+          ISSUE_NUMBER=$(printf '%s\n' "$PR_BODY" | grep -oiP "(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:#\K\d+|https://github\.com/${REPO_REGEX}/issues/\K\d+)" | head -1 || true)
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "No linked issue found in PR body, skipping."
             exit 0
@@ -41,11 +42,15 @@ jobs:
           fi
           echo "Source PR URL: $SOURCE_PR_URL"
 
-          # Parse owner/repo/number from URL
-          SOURCE_PATH=$(echo "$SOURCE_PR_URL" | grep -oP '(?<=github\.com/).+')
-          SOURCE_OWNER=$(echo "$SOURCE_PATH" | cut -d/ -f1)
-          SOURCE_REPO=$(echo "$SOURCE_PATH" | cut -d/ -f2)
-          SOURCE_PR_NUMBER=$(echo "$SOURCE_PATH" | cut -d/ -f4)
+          # Parse owner/repo/number from URL using shell expansion + validation
+          SOURCE_PATH="${SOURCE_PR_URL#https://github.com/}"
+          if [[ ! "$SOURCE_PATH" =~ ^([^/]+)/([^/]+)/pull/([0-9]+)$ ]]; then
+            echo "Source PR URL is not in the expected format (<owner>/<repo>/pull/<number>), skipping."
+            exit 0
+          fi
+          SOURCE_OWNER="${BASH_REMATCH[1]}"
+          SOURCE_REPO="${BASH_REMATCH[2]}"
+          SOURCE_PR_NUMBER="${BASH_REMATCH[3]}"
 
           # Get the source PR author
           SOURCE_AUTHOR=$(gh api "repos/$SOURCE_OWNER/$SOURCE_REPO/pulls/$SOURCE_PR_NUMBER" --jq '.user.login' || true)

--- a/.github/workflows/request-source-author-review.yml
+++ b/.github/workflows/request-source-author-review.yml
@@ -3,6 +3,9 @@ name: Request source PR author review
 on:
   pull_request:
     types: [opened]
+# Note: pull_request events from forks do not allow requesting reviewers
+# (GITHUB_TOKEN is read-only for forks). This workflow is designed for
+# PRs opened directly in this repo (e.g. by Copilot), not fork PRs.
 
 permissions:
   pull-requests: write
@@ -31,11 +34,16 @@ jobs:
           fi
           echo "Linked issue: #$ISSUE_NUMBER"
 
-          # Get issue body
-          ISSUE_BODY=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.body // ""')
+          # Get issue body (guard against API failures — skip rather than fail the PR check)
+          ISSUE_BODY=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.body // ""' || true)
+          if [ -z "$ISSUE_BODY" ]; then
+            echo "Could not retrieve issue body for #$ISSUE_NUMBER, skipping."
+            exit 0
+          fi
 
-          # Extract source PR URL (line: "Source PR URL: https://github.com/.../pull/N")
-          SOURCE_PR_URL=$(echo "$ISSUE_BODY" | grep -oP 'https://github\.com/\S+/pull/\d+' | head -1 || true)
+          # Extract source PR URL from the specific "Source PR URL:" label to avoid
+          # picking up other PR links in the issue body (related PRs, etc.)
+          SOURCE_PR_URL=$(printf '%s\n' "$ISSUE_BODY" | grep -oiPm1 '^[[:space:]]*Source PR URL:[[:space:]]*\Khttps://github\.com/[^[:space:]/]+/[^[:space:]/]+/pull/[0-9]+' || true)
           if [ -z "$SOURCE_PR_URL" ]; then
             echo "No source PR URL found in issue #$ISSUE_NUMBER, skipping."
             exit 0

--- a/.github/workflows/request-source-author-review.yml
+++ b/.github/workflows/request-source-author-review.yml
@@ -1,0 +1,61 @@
+name: Request source PR author review
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find source PR author and request review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Extract linked issue number from PR body (Closes/Fixes/Resolves #N)
+          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oiP '(?<=closes #|fixes #|resolves #)\d+' | head -1 || true)
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No linked issue found in PR body, skipping."
+            exit 0
+          fi
+          echo "Linked issue: #$ISSUE_NUMBER"
+
+          # Get issue body
+          ISSUE_BODY=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.body // ""')
+
+          # Extract source PR URL (line: "Source PR URL: https://github.com/.../pull/N")
+          SOURCE_PR_URL=$(echo "$ISSUE_BODY" | grep -oP 'https://github\.com/\S+/pull/\d+' | head -1 || true)
+          if [ -z "$SOURCE_PR_URL" ]; then
+            echo "No source PR URL found in issue #$ISSUE_NUMBER, skipping."
+            exit 0
+          fi
+          echo "Source PR URL: $SOURCE_PR_URL"
+
+          # Parse owner/repo/number from URL
+          SOURCE_PATH=$(echo "$SOURCE_PR_URL" | grep -oP '(?<=github\.com/).+')
+          SOURCE_OWNER=$(echo "$SOURCE_PATH" | cut -d/ -f1)
+          SOURCE_REPO=$(echo "$SOURCE_PATH" | cut -d/ -f2)
+          SOURCE_PR_NUMBER=$(echo "$SOURCE_PATH" | cut -d/ -f4)
+
+          # Get the source PR author
+          SOURCE_AUTHOR=$(gh api "repos/$SOURCE_OWNER/$SOURCE_REPO/pulls/$SOURCE_PR_NUMBER" --jq '.user.login' || true)
+          if [ -z "$SOURCE_AUTHOR" ] || [ "$SOURCE_AUTHOR" = "null" ]; then
+            echo "Could not determine source PR author, skipping."
+            exit 0
+          fi
+          echo "Source PR author: $SOURCE_AUTHOR"
+
+          # Request review (silently skip if user can't be requested, e.g. bots)
+          gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+            -X POST \
+            --field "reviewers[]=$SOURCE_AUTHOR" \
+            --silent && echo "Requested review from $SOURCE_AUTHOR" \
+            || echo "Could not request review from $SOURCE_AUTHOR (may not have access), skipping."

--- a/.github/workflows/request-source-author-review.yml
+++ b/.github/workflows/request-source-author-review.yml
@@ -2,7 +2,7 @@ name: Request source PR author review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited, reopened]
 # Note: pull_request events from forks do not allow requesting reviewers
 # (GITHUB_TOKEN is read-only for forks). This workflow is designed for
 # PRs opened directly in this repo (e.g. by Copilot), not fork PRs.

--- a/.github/workflows/request-source-author-review.yml
+++ b/.github/workflows/request-source-author-review.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: read
 
 jobs:
   request-review:
@@ -20,8 +21,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract linked issue number from PR body (Closes/Fixes/Resolves #N)
-          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oiP '(?<=closes #|fixes #|resolves #)\d+' | head -1 || true)
+          # Extract linked issue number from PR body.
+          # Handles: "Closes #N", "Fixes: #N", "Resolves #N", full issue URLs, etc.
+          ISSUE_NUMBER=$(echo "$PR_BODY" | grep -oiP '(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*(?:#\K\d+|https://github\.com/[^[:space:]]+/issues/\K\d+)' | head -1 || true)
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "No linked issue found in PR body, skipping."
             exit 0


### PR DESCRIPTION
## Summary

When Copilot (or anyone) opens a docs PR that closes a docs issue, automatically request a review from the author of the original risingwave PR that triggered the docs issue.

**Flow:**
1. Docs issue body contains `Source PR URL: https://github.com/risingwavelabs/risingwave/pull/N`
2. Copilot opens a docs PR with `Closes #<issue>` in the body
3. This workflow runs on PR open, parses `Closes #N` → looks up issue → extracts `Source PR URL` → fetches the PR author → requests their review

**Example:** issue #1129 references risingwave/pull/25396 (author: `wenym1`) — when Copilot's docs PR opens, `wenym1` gets a review request automatically.

Uses built-in `GITHUB_TOKEN` with `pull-requests: write`. Silently skips if no linked issue, no source PR URL, or the author can't be requested.

## Test plan
- [ ] Merge and let Copilot open a docs PR for a pending issue — verify the source PR author receives a review request

🤖 Generated with [Claude Code](https://claude.com/claude-code)