### PR TITLE
docs: mark v2.7.[0-3], v2.8.[0-1], and rc versions as deprecated

### DIFF
--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -24,6 +24,10 @@ description: This page summarizes changes in each version of RisingWave, includi
 
 Support for certain earlier versions will end following the release of v2.8. Please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
 
+<Warning>
+Versions `v2.8.0-rc.1`, `v2.8.0`, and `v2.8.1` are deprecated. We recommend upgrading to `v2.8.2` or later.
+</Warning>
+
 ## SQL features
 
 - SQL commands:
@@ -61,6 +65,10 @@ See the **Full Changelog** [here](https://github.com/risingwavelabs/risingwave/c
 <Update label="v2.7.0" description="2025-12-13">
 
 Support for certain earlier version will end following the release of v2.7, please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
+
+<Warning>
+Versions `v2.7.0-rc.1`, `v2.7.0`, `v2.7.1`, `v2.7.2`, and `v2.7.3` are deprecated. We recommend upgrading to `v2.7.4` or later.
+</Warning>
 
 ## Upgrade-time behavior changes
 

--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -64,7 +64,7 @@ See the **Full Changelog** [here](https://github.com/risingwavelabs/risingwave/c
 
 <Update label="v2.7.0" description="2025-12-13">
 
-Support for certain earlier version will end following the release of v2.7, please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
+Support for certain earlier versions will end following the release of v2.7. Please plan your upgrade to a newer version soon to ensure continued support and updates. For more details, see our [version support policy](/changelog/release-support-policy).
 
 <Warning>
 Versions `v2.7.0-rc.1`, `v2.7.0`, `v2.7.1`, `v2.7.2`, and `v2.7.3` are deprecated. We recommend upgrading to `v2.7.4` or later.


### PR DESCRIPTION
This PR adds deprecation warnings to the release notes for older patch and RC versions:

- **v2.7.x**: Marks `v2.7.0-rc.1`, `v2.7.0`, `v2.7.1`, `v2.7.2`, and `v2.7.3` as deprecated. Recommends upgrading to `v2.7.4` or later.
- **v2.8.x**: Marks `v2.8.0-rc.1`, `v2.8.0`, and `v2.8.1` as deprecated. Recommends upgrading to `v2.8.2` or later.