### PR TITLE
docs(byok): clarify EKS access entry requires AmazonEKSClusterAdminPolicy

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -142,7 +142,7 @@ You must create the following IAM roles:
 This role is used by the person or CI/CD pipeline running the BYOK setup commands. It is not used by any in-cluster workloads.
 
 - Must have `eks:DescribeCluster` permission on the target EKS cluster.
-- Must have an [access entry](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) in the EKS cluster.
+- Must have an [access entry](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) in the EKS cluster with the `AmazonEKSClusterAdminPolicy` access policy attached.
 
 **B. CloudAgent IAM (service context)**
 


### PR DESCRIPTION
## Summary
- Clarify in [cloud/project-byok#5-identity-and-access-management](https://docs.risingwave.com/cloud/project-byok#5-identity-and-access-management) that the EKS access entry for the Setup IAM role must have the `AmazonEKSClusterAdminPolicy` access policy attached.

## Test plan
- [ ] Preview rendered docs page
- [ ] Verify the link to the AWS access entries doc still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)