### PR TITLE
docs(cloud): document EBS CSI role KMS permissions for BYOK

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -127,7 +127,7 @@ Provide the S3 bucket **ARNs** for both buckets.
 Provide a KMS key ARN for EBS encryption. This is used by VictoriaMetrics and Loki persistent volumes, and RisingWave compute cache storage.
 
 <Warning>
-The KMS key policy must allow this key to be used for EBS encryption, either directly or by delegating access to IAM principals. Depending on your setup, the EBS CSI driver's IAM role may also need the relevant KMS permissions. Otherwise, persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
+The KMS key policy must allow this key to be used for EBS encryption, either directly or by delegating access to IAM principals. Depending on your setup, the IAM principal used by the EBS CSI controller may also need the relevant KMS permissions. Otherwise, persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
 </Warning>
 </Tab>
 <Tab title="GCP">

--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -127,7 +127,7 @@ Provide the S3 bucket **ARNs** for both buckets.
 Provide a KMS key ARN for EBS encryption. This is used by VictoriaMetrics and Loki persistent volumes, and RisingWave compute cache storage.
 
 <Warning>
-The KMS key policy must allow this key to be used for EBS encryption, either directly or by delegating access to IAM principals. Depending on your setup, the EBS CSI driver's IAM role may also need the relevant KMS permissions. Otherwise persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
+The KMS key policy must allow this key to be used for EBS encryption, either directly or by delegating access to IAM principals. Depending on your setup, the EBS CSI driver's IAM role may also need the relevant KMS permissions. Otherwise, persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
 </Warning>
 </Tab>
 <Tab title="GCP">

--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -127,7 +127,7 @@ Provide the S3 bucket **ARNs** for both buckets.
 Provide a KMS key ARN for EBS encryption. This is used by VictoriaMetrics and Loki persistent volumes, and RisingWave compute cache storage.
 
 <Warning>
-The EBS CSI driver must be authorized to use this KMS key — either via the KMS key policy or via the EBS CSI driver's IAM role. Otherwise persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
+The KMS key policy must allow this key to be used for EBS encryption, either directly or by delegating access to IAM principals. Depending on your setup, the EBS CSI driver's IAM role may also need the relevant KMS permissions. Otherwise persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
 </Warning>
 </Tab>
 <Tab title="GCP">

--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -125,6 +125,10 @@ Provide the S3 bucket **ARNs** for both buckets.
 <Tabs>
 <Tab title="AWS">
 Provide a KMS key ARN for EBS encryption. This is used by VictoriaMetrics and Loki persistent volumes, and RisingWave compute cache storage.
+
+<Warning>
+The EBS CSI driver must be authorized to use this KMS key — either via the KMS key policy or via the EBS CSI driver's IAM role. Otherwise persistent volume claims for VictoriaMetrics, Loki, and the RisingWave compute cache will stay `Pending` and `rwc byok apply` will fail. See the [reference Terraform example](https://github.com/risingwavelabs/risingwave-byok-terraform-example/blob/main/aws/base_env/kms.tf) for a working KMS key policy.
+</Warning>
 </Tab>
 <Tab title="GCP">
 <Note>GCP GKE support is planned. Stay tuned.</Note>


### PR DESCRIPTION
## Summary

- Adds a `Warning` callout under BYOK prerequisite §4 (Encryption at rest) noting that the EBS CSI driver must be authorized to use the customer KMS key — otherwise VictoriaMetrics / Loki / compute-cache PVCs stay `Pending` and `rwc byok apply` fails.
- Surfaced during BYOK M1 QA on RLS (PERF-288).
- Links the reference Terraform example as the canonical working setup; intentionally avoids prescribing one specific policy form so customers can use whichever authorization path fits their existing IAM/KMS setup.

Resolves CLOUD-4906.

## Test plan

- [ ] Mintlify preview renders the new `Warning` correctly.
- [ ] Spellcheck CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)