### PR TITLE
docs(msk): drop misleading note on AWS credential requirements

### DIFF
--- a/integrations/sources/amazon-msk.mdx
+++ b/integrations/sources/amazon-msk.mdx
@@ -216,10 +216,6 @@ To access MSK using IAM, you need to use the `AWS_MSK_IAM` SASL mechanism. You a
 | aws.credentials.role.external_id   | **Optional**. The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.                                 |
 | aws.msk.signer_timeout_sec | **Optional**. The timeout limit for loading AWS credentials of AWS MSK.|
 
-<Note>
-In RisingWave Cloud, AWS credentials (`aws.credentials.access_key_id`, `aws.credentials.secret_access_key`) are required and cannot be omitted. In self-hosted deployments, you may omit them to rely on the AWS SDK default credential chain (for example, EC2 instance profile or environment variables).
-</Note>
-
 Here is an example of creating a sink authenticated with `AWS_MSK_IAM` on AWS.
 
 ```sql


### PR DESCRIPTION
## Summary
Drops the `<Note>` block on the MSK source page that claimed AWS access keys are required and cannot be omitted in RisingWave Cloud. The claim is no longer accurate: BYOC and self-hosted deployments both support the default credential chain (IRSA, EC2 instance profile, env vars) and cross-account `sts:AssumeRole` via `aws.credentials.role.arn`.

The parameter table already labels the access key/secret key fields as **Conditional** and `aws.credentials.role.arn` as **Optional**, so removing the note is sufficient — no replacement copy needed.

Surfaced while debugging a customer ([Slack thread](https://risingwave-labs.slack.com/archives/C0AHNJY31QS/p1778186144407289)) whose source DDL was failing because they read this note and assumed they had to provision static keys, while their org's SCP forbids `iam:CreateUser`.

## Test plan
- [ ] Mintlify deployment preview renders the page cleanly with the note removed
- [ ] Spellcheck workflow passes
- [ ] Broken-links workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)