### PR TITLE
docs(cloud/byok): fix tenant IAM policy to cover data and backup prefixes

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -546,7 +546,7 @@ Look for the `Resource Namespace` and `Service Account` fields in the output. Yo
    }
    ```
 
-   Grant S3 access to the data store bucket:
+   Grant S3 access to the cluster's data and backup prefixes in the data store bucket. RisingWave stores cluster state under `data-$RESOURCE_NAMESPACE/` and meta backups under `data-$RESOURCE_NAMESPACE-backup/`, so both prefixes must be included:
 
    ```json
    {
@@ -557,7 +557,8 @@ Look for the `Resource Namespace` and `Service Account` fields in the output. Yo
                "Action": "s3:*",
                "Resource": [
                    "arn:aws:s3:::$DATA_STORE_BUCKET",
-                   "arn:aws:s3:::$DATA_STORE_BUCKET/$RESOURCE_NAMESPACE/*"
+                   "arn:aws:s3:::$DATA_STORE_BUCKET/data-$RESOURCE_NAMESPACE/*",
+                   "arn:aws:s3:::$DATA_STORE_BUCKET/data-$RESOURCE_NAMESPACE-backup/*"
                ]
            }
        ]


### PR DESCRIPTION
## Summary
- The BYOK tenant IAM example in `cloud/project-byok.mdx` granted `s3:*` on `arn:aws:s3:::$DATA_STORE_BUCKET/$RESOURCE_NAMESPACE/*`, but the actual object keys laid out by the BYOK AWS provisioner are `data-$RESOURCE_NAMESPACE/...` (state store) and `data-$RESOURCE_NAMESPACE-backup/...` (meta backups). The documented policy doesn't match either path.
- Update the example so both prefixes are covered, and add a one-liner noting the layout.

## Why the existing example "worked" in testing
The reference Terraform module at `risingwavelabs/risingwave-byok-terraform-example` granted `s3:*` on the whole bucket (`$DATA_STORE_BUCKET/*`), so it masked the doc mismatch end-to-end. A follow-up PR tightens that module to match the doc.

## Verified against a live cluster
Pulled from a real BYOK cluster (`rwc-g1jofnfov0eatrfpvrcu9tklns-rwc-sandbox-byok`):
- RisingWave CR: `stateStore.dataDirectory: data-rwc-g1jofnfov0eatrfpvrcu9tklns-rwc-sandbox-byok`
- Meta ConfigMap: `backup_storage_directory = "data-rwc-g1jofnfov0eatrfpvrcu9tklns-rwc-sandbox-byok-backup"`

## Test plan
- [ ] Render preview and confirm the JSON block renders correctly
- [ ] Cross-check with the companion fix in `risingwavelabs/risingwave-byok-terraform-example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)