### PR TITLE
docs(cloud/byok): grant CloudAgent IAM access to terraform state backend

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -150,23 +150,41 @@ This role is used by the person or CI/CD pipeline running the BYOK8s setup comma
 
 **B. CloudAgent IAM (service context)**
 
-This role is assumed by CloudAgent via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). Minimum permissions:
+This role is assumed by CloudAgent via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). CloudAgent needs access to both the data store bucket (for cluster state operations) and the [Terraform state backend](#7-terraform-state-backend) (S3 bucket plus DynamoDB lock table) that it uses to manage in-cluster resources. Minimum permissions:
 
 ```json
 {
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "DataStore",
             "Effect": "Allow",
             "Action": "s3:*",
             "Resource": [
                 "arn:aws:s3:::$DATA_STORE_BUCKET",
                 "arn:aws:s3:::$DATA_STORE_BUCKET/*"
             ]
+        },
+        {
+            "Sid": "TerraformStateBucket",
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "arn:aws:s3:::$TFSTATE_BUCKET",
+                "arn:aws:s3:::$TFSTATE_BUCKET/*"
+            ]
+        },
+        {
+            "Sid": "TerraformStateLock",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": "arn:aws:dynamodb:$REGION:$ACCOUNT_ID:table/$TFLOCK_TABLE"
         }
     ]
 }
 ```
+
+Where `$TFSTATE_BUCKET` and `$TFLOCK_TABLE` correspond to the S3 bucket and DynamoDB table provisioned in [Terraform state backend](#7-terraform-state-backend).
 
 **C. Loki IAM (service context)**
 


### PR DESCRIPTION
## Summary
- The Phase 1, Step 5.B CloudAgent IAM example only granted S3 on the data store bucket. CloudAgent also needs read/write access to the Terraform state backend (S3 bucket + DynamoDB lock table from Phase 1, Step 7) that it uses to manage in-cluster Terraform resources.
- Add the missing `TerraformStateBucket` and `TerraformStateLock` statements, with `Sid`s on each statement for clarity, and a short note pointing at Step 7.

## Why it wasn't caught
The reference Terraform module (`risingwave-byok-terraform-example/aws/base_env/iam.tf`) already attaches both policies (`cloudagent_s3` + `cloudagent_tfstate`) to the CloudAgent IRSA role, so E2E never exercised the doc snippet verbatim.

## Test plan
- [ ] Render preview and confirm the JSON renders correctly
- [ ] Confirm placeholder names match Step 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)