### PR TITLE
docs(cloud/byok): clarify RWProxy webhook listener port (443) vs target port (4580)

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -235,13 +235,13 @@ Provision **two** internal Network Load Balancers with VPC Endpoint Services for
 | 40001 | TCP | Service port |
 | 40090 | TCP | Metrics and status |
 
-**RWProxy NLB** — one target group per port:
+**RWProxy NLB** — one target group per port. The webhook listener port differs from its target port (the control plane reaches it on `443` over TLS; the RWProxy pod listens on `4580`); pgwire and metrics use the same port on both sides.
 
-| Port | Protocol | Purpose |
-| --- | --- | --- |
-| 4566 | TCP | PostgreSQL protocol |
-| 4580 | TCP | Webhook |
-| 9099 | TCP | Metrics and status |
+| Listener port | Target port | Protocol | Purpose |
+| --- | --- | --- | --- |
+| 4566 | 4566 | TCP | PostgreSQL protocol |
+| 443  | 4580 | TCP | Webhook (HTTPS) |
+| 9099 | 9099 | TCP | Metrics and status |
 
 For each NLB, create a [VPC Endpoint Service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html) and allow the RisingWave control plane AWS account (`600598779918`) as an allowed principal.
 
@@ -353,7 +353,7 @@ resource "aws_lb_listener" "rwproxy_metrics" {
 
 resource "aws_lb_listener" "rwproxy_webhook" {
   load_balancer_arn = aws_lb.rwproxy.arn
-  port              = 4580
+  port              = 443 # externally exposed listener port; target group still forwards to pod port 4580
   protocol          = "TCP"
   default_action {
     type             = "forward"


### PR DESCRIPTION
## Summary
The RWProxy NLB port table listed webhook on \`4580\`, but the deployed RWProxy expects external callers on **443** (TLS) and listens internally on **4580** (\`risingwave-cloud/deploy/k8s/harness/rwproxy/values.yaml:19-20\`: \`rwproxyWebhookListenerPort: 443\`, \`rwproxyWebhookTargetPort: 4580\`). Customers following the doc literally would create an NLB listener on 4580, which the control plane cannot reach via VPCE.

## Changes
- Split the RWProxy port table into **Listener port / Target port** columns so the 443/4580 split is explicit; pgwire and metrics use the same value on both sides.
- Update \`aws_lb_listener.rwproxy_webhook\` in the example HCL from port 4580 → 443, with a comment pointing at the target.

## Test plan
- [ ] Render preview — table renders correctly with 4 columns
- [ ] Cross-check that the reference Terraform module (\`risingwave-byok-terraform-example/aws/base_env/variables.tf:88-92\`) already defaults to listener=443 / target=4580

🤖 Generated with [Claude Code](https://claude.com/claude-code)