### PR TITLE
Fix typo

### DIFF
--- a/operate/alter-streaming.mdx
+++ b/operate/alter-streaming.mdx
@@ -59,7 +59,7 @@ To alter a sink, you will need to create a new sink and drop the old sink. Pleas
 If your sink is created based on a materialized view using the `CREATE SINK ... FROM ...` statement, you have the option to specify `snapshot = false` to exclude existing data.
 
 ```
-CREATE SINK ... FROM ... WITH (snapshot = false).
+CREATE SINK ... FROM ... WITH (snapshot = false);
 ```
 
 ## Alter streaming jobs with dependencies

--- a/operate/alter-streaming.mdx
+++ b/operate/alter-streaming.mdx
@@ -56,10 +56,10 @@ ALTER MATERIALIZED VIEW cust_sales_new RENAME TO cust_sales;
 
 To alter a sink, you will need to create a new sink and drop the old sink. Please check the example from the last section.
 
-If your sink is created based on a materialized view using the `CREATE SINK ... FROM ...` statement, you have the option to specify `without_backfill = true` to exclude existing data.
+If your sink is created based on a materialized view using the `CREATE SINK ... FROM ...` statement, you have the option to specify `snapshot = false` to exclude existing data.
 
 ```
-CREATE SINK ... FROM ... WITH (without_backfill = true).
+CREATE SINK ... FROM ... WITH (snapshot = false).
 ```
 
 ## Alter streaming jobs with dependencies


### PR DESCRIPTION
## Description

According to Yiming Wen, the correct option should be `snapshot`, not `without_backfill`.

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `docs.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
