### PR TITLE
docs(console): legacy console version w/o license key

### DIFF
--- a/web-ui/risingwave-console/installation-setup.mdx
+++ b/web-ui/risingwave-console/installation-setup.mdx
@@ -5,7 +5,7 @@ description: "Deploy RisingWave Console with Docker, Kubernetes, or a standalone
 
 RisingWave Console is a self-hosted service. It stores its own metadata, such as users, cluster connections, database connections, tasks, and settings, in PostgreSQL. It does not store RisingWave user data in this metadata database.
 
-Production builds require the signed RisingWave license key at startup. This is the same license key used by the RisingWave database. Provide it with either `RW_LICENSE_KEY` or `RW_LICENSE_KEY_PATH`. For details about where to configure the key, see [Manage license keys](/web-ui/risingwave-console/license-management).
+Production builds require the signed RisingWave license key at startup. This is the same license key used by the RisingWave database. Provide it with either `RW_LICENSE_KEY` or `RW_LICENSE_KEY_PATH`. If you only want to try Console without configuring a license key, use `v0.5.1`; it is an older evaluation version and does not include all current capabilities. For details, see [Manage license keys](/web-ui/risingwave-console/license-management).
 
 ## Choose a deployment target
 

--- a/web-ui/risingwave-console/license-management.mdx
+++ b/web-ui/risingwave-console/license-management.mdx
@@ -14,6 +14,17 @@ The key is the same, but operators configure it in different places depending on
 
 In other words, Console does not use a separate product license key. It uses the same RisingWave license key, provided once to Console for startup and separately to any managed RisingWave database cluster that needs the database-side license.
 
+## Try without a license key
+
+If you only want to try RisingWave Console without configuring a license key, use `v0.5.1`:
+
+```shell
+docker run --rm -p 8020:8020 --name risingwave-console \
+  risingwavelabs/risingwave-console:v0.5.1-pgbundle
+```
+
+`v0.5.1` is an older evaluation version. It does not include all current Console capabilities, and some features described in this documentation may not exist or may behave differently in that version. For current supported versions, configure the signed RisingWave license key as described below.
+
 ## Console startup license
 
 Production Console builds verify the signed RisingWave license key during startup. Console exits if the key is missing, invalid, expired, or does not include the `premium` feature.

--- a/web-ui/risingwave-console/prerequisites.mdx
+++ b/web-ui/risingwave-console/prerequisites.mdx
@@ -16,6 +16,8 @@ Production Console builds verify a signed RisingWave license key during startup.
 
 For Docker and Kubernetes deployments, storing the license key value in `RW_LICENSE_KEY_PATH` or a Kubernetes Secret is preferred so the token is not embedded in command history or plain manifests.
 
+If you only want to try Console without configuring a license key, use `v0.5.1`. This is an older evaluation version and does not include all current Console capabilities, so some features described in this documentation may not exist in that version.
+
 Console uses the same signed RisingWave license key as the RisingWave database. Configure the same key in different places depending on what needs to read it:
 
 - The **Console startup license** lets the Console service start and unlocks Console premium features.


### PR DESCRIPTION
## Description

- legacy console tag w/o license key for free trial

## Related code PR


## Related doc issue



## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `docs.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
