### PR TITLE
refactor: update restore doc

### DIFF
--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -74,7 +74,7 @@ Below are two separate methods to restore from a meta snapshot using SQL databas
 
 If the cluster has been using a SQL database as meta store backend, follow these steps to restore from a meta snapshot.
 
-1. Shut down the meta service.
+1. Shut down RisingWave nodes, including meta, compute, compactor and frontend.
    <Note>
    This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
    </Note>
@@ -128,7 +128,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
 
 If the cluster has been using etcd as meta store backend, follow these steps to restore from a meta snapshot.
 
-1. Shut down the meta service.
+1. Shut down RisingWave nodes, including meta, compute, compactor and frontend.
    <Note>
    This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
    </Note>


### PR DESCRIPTION
## Description

Compute and compactor may have cached SST Ids fetched prior to restore, which are larger than the restored start SST Id.
- Without shutting down the compute and compactor nodes, the SST files associated with these cached SST IDs may eventually be overwritten following the restore.
- However, it will not cause permanent data corruption because the SSTs required by the meta snapshot will never be overwritten. So another restore with Compute and compactor shutdown will resolve the issue.

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `docs.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
