### PR TITLE
refactor: update meta restore doc

### DIFF
--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -78,11 +78,14 @@ If the cluster has been using a SQL database as meta store backend, follow these
    <Note>
    This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
    </Note>
-2. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. To achieve this, you can either: 
+
+2. Clear the folders used by disk cache feature, if enabled.
+
+3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. To achieve this, you can either: 
    * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas, or
    * Use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model/migration) to create tables, then truncate those non-empty tables populated by the tool. The version of the migration tool must match the version of the meta snapshot. For example, if the meta snapshot was created with RisingWave v2.4.3, the migration tool should also be from RisingWave v2.4.3.
 
-3. Restore the meta snapshot to the new meta store.
+4. Restore the meta snapshot to the new meta store.
    ```
    risectl \
    meta \
@@ -122,7 +125,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
    - `--overwrite-backup-storage-directory`: Override backup storage directory in restored meta store
    - `--sql-url-params`: Additional SQL connection parameters (e.g., `sslmode=disable`)
 
-4. Configure meta service to use the new meta store.
+5. Configure meta service to use the new meta store.
 
 ### etcd as meta store backends
 

--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -79,7 +79,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
    This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
    </Note>
 
-2. If the Elastic Disk Cache feature is enabled, clear the disk cache directories on every node where disk cache is enabled before starting the restored cluster. Specifically, remove the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`.
+2. If the Elastic Disk Cache feature is enabled, clear the disk cache on every node where disk cache is enabled before starting the restored cluster. Specifically, delete the contents of the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`, or delete and then recreate those directories with the correct permissions before starting the restored cluster.
 
 3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. To achieve this, you can either: 
    * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas, or

--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -79,7 +79,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
    This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
    </Note>
 
-2. Clear the folders used by disk cache feature, if enabled.
+2. If the Elastic Disk Cache feature is enabled, clear the disk cache directories on every node where disk cache is enabled before starting the restored cluster. Specifically, remove the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`.
 
 3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. To achieve this, you can either: 
    * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas, or


### PR DESCRIPTION
## Description

A restored cluster must not use stale SSTs files in disk cache created by previous cluster.
This PR adds the instruction for clearing disk during restore.

## Related code PR

[ Link to the related code pull request (if any). ]

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `docs.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
