### PR TITLE
docs(cloud): document allowed BYOK metastore password alphabet

### DIFF
--- a/cloud/project-byok.mdx
+++ b/cloud/project-byok.mdx
@@ -585,6 +585,10 @@ Look for the `Resource Namespace` and `Service Account` fields in the output. Yo
 
 2. **Provision a PostgreSQL database** as the metadata store. We recommend using [Amazon RDS](https://aws.amazon.com/rds/). Ensure connectivity from the EKS cluster pods to the database.
 
+   <Warning>
+   Choose the metastore password using only these characters: uppercase and lowercase letters (`A-Z`, `a-z`), digits (`0-9`), and the four symbols underscore (`_`), tilde (`~`), period (`.`), and hyphen (`-`). No other characters are allowed — in particular, spaces and symbols such as `@`, `/`, and `:` are not. RisingWave Cloud embeds this password in the metastore connection URL, so a password containing unsupported characters is rejected by `rwc cluster byok-config` with an HTTP 400 error, even though your database may accept it. Fixing that means rotating the password and reconfiguring the database, so pick a compliant one before you create the database.
+   </Warning>
+
 3. **Submit the configuration** via CLI:
 
    ```bash


### PR DESCRIPTION
## What

Adds a `<Warning>` at the "Provision a PostgreSQL database" step of BYOK Phase 2 in `cloud/project-byok.mdx`, documenting the exact allowed metastore-password alphabet: `A-Z a-z 0-9 _ ~ . -`.

## Why

From [PERF-292 comment](https://linear.app/risingwave-labs/issue/PERF-292/byok-test#comment-439ee662): metastore password validation happens too late. RisingWave Cloud embeds the password in the metastore connection URL, so `rwc cluster byok-config` rejects anything outside the RFC 3986 unreserved alphabet with HTTP 400 — but the database (e.g. RDS) accepts a wider set. Users discover the restriction only *after* provisioning, forcing a password rotation + reconfigure.

The docs previously said "Provision a PostgreSQL database" and showed `password: "..."` with no guidance on allowed characters. This warning moves that knowledge to the moment the user chooses the password.

## Verification

- `<Warning>` open/close tags balanced.
- No new non-dictionary terms (spellcheck globs root `*.mdx` only; all wording is standard English; `metastore` already appears throughout the page).

Companion to the Terraform-example plan-time validation (CLOUD-5104 / example-repo PR #36).

Closes CLOUD-5105

🤖 Generated with [Claude Code](https://claude.com/claude-code)