### PR TITLE
refactor(meta): add create-meta-store-schema instruction

### DIFF
--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -93,7 +93,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
       --sql-database placeholder
      ```
      * For RisingWave prior to v3.1, use the [dedicated risectl image](https://github.com/risingwavelabs/risingwave/pkgs/container/risectl) that supports create-meta-store-schema. Ensure risectl image version matches your meta snapshot. For example, for a RisingWave v2.8.3 meta snapshot, use risectl v2.8.
-     ```
+      ```bash
      /risingwave/bin/risectl meta create-meta-store-schema \
       --meta-store-type postgres \
       --sql-endpoint 127.0.0.1:8432 \
@@ -101,7 +101,7 @@ If the cluster has been using a SQL database as meta store backend, follow these
       --sql-password placeholder \
       --sql-database placeholder
      ```
-       Then truncate the tables populated during create-meta-store-schema, such as seaql_migrations.
+      * After running the command, truncate tables populated during `create-meta-store-schema`, such as `seaql_migrations`.
    * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas.
    * Use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model/migration) to create tables, then truncate those non-empty tables populated by the tool. The version of the migration tool must match the version of the meta snapshot. For example, if the meta snapshot was created with RisingWave v2.4.3, the migration tool should also be from RisingWave v2.4.3.
 

--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -82,8 +82,8 @@ If the cluster has been using a SQL database as meta store backend, follow these
 2. If the Elastic Disk Cache feature is enabled, clear the disk cache on every node where disk cache is enabled before starting the restored cluster. Specifically, delete the contents of the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`, or delete and then recreate those directories with the correct permissions before starting the restored cluster.
 
 3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. Use one of the following methods to achieve this:
-   * (Preferred) Create the meta store schema using the risectl create-meta-store-schema. 
-     * For RisingWave v3.1 and above, use the RisingWave image where the embedded risectl supports create-meta-store-schema. Ensure RisingWave image version matches your meta snapshot.
+   * (Preferred) Create the meta store schema using `risectl meta create-meta-store-schema`.
+     * For RisingWave v3.1 and above, use the RisingWave image where the embedded `risectl` supports `create-meta-store-schema`. Ensure the RisingWave image version matches your meta snapshot.
      ```
      /risingwave/bin/risingwave ctl meta create-meta-store-schema \
       --meta-store-type postgres \

--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -82,16 +82,26 @@ If the cluster has been using a SQL database as meta store backend, follow these
 2. If the Elastic Disk Cache feature is enabled, clear the disk cache on every node where disk cache is enabled before starting the restored cluster. Specifically, delete the contents of the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`, or delete and then recreate those directories with the correct permissions before starting the restored cluster.
 
 3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. Use one of the following methods to achieve this:
-   * (Preferred) Create the meta store schema using the pre-built risectl Docker image. The risectl version must match the meta snapshot version (e.g., use image tag v2.8 if the snapshot was created with RisingWave v2.8.*).
-   ```
-   /risingwave/bin/risectl meta create-meta-store-schema \
-    --meta-store-type postgres \
-    --sql-endpoint 127.0.0.1:8432 \
-    --sql-username placeholder \
-    --sql-password placeholder \
-    --sql-database placeholder
-   ```
-   Then truncate the tables populated during create-meta-store-schema, such as seaql_migrations.
+   * (Preferred) Create the meta store schema using the risectl create-meta-store-schema. 
+     * For RisingWave v3.1 and above, use the RisingWave image where the embedded risectl supports create-meta-store-schema. Ensure RisingWave image version matches your meta snapshot.
+     ```
+     /risingwave/bin/risingwave ctl meta create-meta-store-schema \
+      --meta-store-type postgres \
+      --sql-endpoint 127.0.0.1:8432 \
+      --sql-username placeholder \
+      --sql-password placeholder \
+      --sql-database placeholder
+     ```
+     * For RisingWave prior to v3.1, use the [dedicated risectl image](https://github.com/risingwavelabs/risingwave/pkgs/container/risectl) that supports create-meta-store-schema. Ensure risectl image version matches your meta snapshot. For example, for a RisingWave v2.8.3 meta snapshot, use risectl v2.8.
+     ```
+     /risingwave/bin/risectl meta create-meta-store-schema \
+      --meta-store-type postgres \
+      --sql-endpoint 127.0.0.1:8432 \
+      --sql-username placeholder \
+      --sql-password placeholder \
+      --sql-database placeholder
+     ```
+       Then truncate the tables populated during create-meta-store-schema, such as seaql_migrations.
    * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas.
    * Use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model/migration) to create tables, then truncate those non-empty tables populated by the tool. The version of the migration tool must match the version of the meta snapshot. For example, if the meta snapshot was created with RisingWave v2.4.3, the migration tool should also be from RisingWave v2.4.3.
 

--- a/operate/meta-backup.mdx
+++ b/operate/meta-backup.mdx
@@ -81,8 +81,18 @@ If the cluster has been using a SQL database as meta store backend, follow these
 
 2. If the Elastic Disk Cache feature is enabled, clear the disk cache on every node where disk cache is enabled before starting the restored cluster. Specifically, delete the contents of the directories configured by `storage.meta_file_cache.dir` and `storage.data_file_cache.dir`, or delete and then recreate those directories with the correct permissions before starting the restored cluster.
 
-3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. To achieve this, you can either: 
-   * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas, or
+3. Create a new meta store, i.e., a new SQL database. This database must have the same table structure as the original, but all tables must be empty. Use one of the following methods to achieve this:
+   * (Preferred) Create the meta store schema using the pre-built risectl Docker image. The risectl version must match the meta snapshot version (e.g., use image tag v2.8 if the snapshot was created with RisingWave v2.8.*).
+   ```
+   /risingwave/bin/risectl meta create-meta-store-schema \
+    --meta-store-type postgres \
+    --sql-endpoint 127.0.0.1:8432 \
+    --sql-username placeholder \
+    --sql-password placeholder \
+    --sql-database placeholder
+   ```
+   Then truncate the tables populated during create-meta-store-schema, such as seaql_migrations.
+   * Use database-specific tools (e.g., `pgdump` for Postgres) to duplicate table schemas.
    * Use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model/migration) to create tables, then truncate those non-empty tables populated by the tool. The version of the migration tool must match the version of the meta snapshot. For example, if the meta snapshot was created with RisingWave v2.4.3, the migration tool should also be from RisingWave v2.4.3.
 
 4. Restore the meta snapshot to the new meta store.


### PR DESCRIPTION
## Description

The risingwave kernel support `risectl create-meta-store-schema` since v3.1.
For prior kernel version, dedicated risectl docker images supporting create-meta-store-schema are provided.

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/26154

## Related doc issue

[ Link to the related documentation issue or task (if any). ]

Fix [ Provide the link to the doc issue here. ]

## Checklist

- [ ] I have run the documentation build locally to verify the updates are applied correctly.  
- [ ] For new pages, I have updated `docs.json` to include the page in the table of contents.  
- [ ] All links and references have been checked and are not broken.
