### PR TITLE
docs: update cloud metadata for GCP

### DIFF
--- a/cloud/cloud-metadata.mdx
+++ b/cloud/cloud-metadata.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Cloud metadata"
 sidebarTitle: "Cloud metadata"
-description: "View and use the cloud metadata values exposed in the RisingWave Cloud Console, including the IAM role ARN, PrivateLink Principal, Serving PrivateLink details, and egress public IPs for your cluster."
+description: "View and use the identity, private connectivity, and egress metadata exposed for AWS and GCP clusters in the RisingWave Cloud Console."
 ---
 
-RisingWave Cloud exposes a set of environment-specific metadata values for each cluster. These values are required when setting up cross-account access (IAM role assume), PrivateLink connections from RisingWave Cloud to services in your VPC, and Serving PrivateLink connections from your VPC to RisingWave Cloud. All values are read-only and are generated automatically when a cluster is created.
+RisingWave Cloud exposes a set of environment-specific metadata values for each cluster. These values are required when setting up cross-account access (IAM role assume on AWS, Workload Identity on GCP), PrivateLink or Private Service Connect connections from RisingWave Cloud to services in your VPC, and Serving PrivateLink (AWS) or Serving Private Service Connect (GCP) connections from your VPC to RisingWave Cloud. All values are read-only and are generated automatically when a cluster is created.
 
 ## Where to find cloud metadata
 
@@ -20,6 +20,9 @@ Cloud metadata is only available for projects on the **Standard** plan or above.
 
 ## Metadata fields
 
+<Tabs>
+<Tab title="AWS">
+
 ### Workload Identity (IAM Role ARN)
 
 | Field | Example value |
@@ -28,13 +31,13 @@ Cloud metadata is only available for projects on the **Standard** plan or above.
 
 The AWS IAM role ARN that RisingWave Cloud uses to access AWS resources on behalf of this project. When you configure [IAM role assume](/cloud/iam-role-assume) (cross-account S3 access), you add this ARN as a trusted principal in your IAM role's trust policy.
 
-### PrivateLink Principal
+### PrivateLink principals
 
 | Field | Example value |
 |:------|:--------------|
-| **PrivateLink Principal** | `arn:aws:iam::023339134545:role/test-useast1-eks-a-cloudagent-role` |
+| **PrivateLink principals** | `arn:aws:iam::023339134545:role/test-useast1-eks-a-cloudagent-role` |
 
-The AWS principal associated with the RisingWave Cloud deployment that hosts your project. When you create a PrivateLink endpoint service in your AWS account, add this principal to the list of **Allowed principals** so that RisingWave Cloud can connect to your service.
+The AWS principals associated with the RisingWave Cloud deployment that hosts your project. When you create a PrivateLink endpoint service in your AWS account, add these principals to the list of **Allowed principals** so that RisingWave Cloud can connect to your service.
 
 ### Serving PrivateLink
 
@@ -57,15 +60,51 @@ The name of the AWS endpoint service created by RisingWave Cloud for your projec
 
 | Field | Example value |
 |:------|:--------------|
-| **Private Endpoint** | `vpce-0a1b2c3d4e5f6a7b8-xyz12345.vpce-svc-0a1b2c3d4e5f6a7b8.us-east-1.vpce.amazonaws.com` |
+| **Private Endpoint** | `vpce-0a1b2c3d4e5f6a7b8-xyz12345.vpce-svc-0a1b2c3d4e5f6a7b8.us-east-1.vpce.amazonaws.com:4566` |
 
-The hostname to use when connecting to RisingWave Cloud privately from your VPC, after the Interface VPC Endpoint is provisioned and accepted. Replace the public RisingWave Cloud hostname with this value in your connection strings and client applications.
+The hostname and port to use when connecting to RisingWave Cloud privately from your VPC, after the Interface VPC Endpoint is provisioned and accepted. Replace the public RisingWave Cloud hostname with this value in your connection strings and client applications.
 
 <Note>
-The **Private Endpoint** hostname is only available after the Interface VPC Endpoint in your AWS account transitions to the **Available** state. If the field is empty, the endpoint has not yet been accepted or provisioned.
+The **Private Endpoint** value is only available after the Interface VPC Endpoint in your AWS account transitions to the **Available** state. If the field is empty, the endpoint has not yet been accepted or provisioned.
 </Note>
 
 For more information, see [PrivateLink overview](/cloud/privatelink-overview).
+
+</Tab>
+<Tab title="GCP">
+
+### Workload Identity (GSA)
+
+| Field | Example value |
+|:------|:--------------|
+| **Workload Identity (GSA)** | `rwc-abc123@example-project.iam.gserviceaccount.com` |
+
+The Google service account that RisingWave Cloud uses to access Google Cloud resources on behalf of this project. Grant this service account the permissions required to access your resources.
+
+### PSC project
+
+| Field | Example value |
+|:------|:--------------|
+| **PSC project** | `123456789012` |
+
+The Google Cloud project associated with RisingWave Cloud Private Service Connect (PSC) connections. Use this value when authorizing RisingWave Cloud to connect to a service published from your VPC through PSC.
+
+### Serving Private Service Connect
+
+The **Serving Private Service Connect** card contains the values required to connect to RisingWave Cloud privately from your Google Cloud VPC.
+
+| Field | Example value |
+|:------|:--------------|
+| **Service attachment URI** | `projects/example-project/regions/us-central1/serviceAttachments/rwproxy-serving` |
+| **DNS suffix** | `privatelink.example.com` |
+| **Private endpoint** | `rwc-abc123.privatelink.example.com:4566` |
+
+Create a PSC endpoint that targets the **Service attachment URI**. Then create a private DNS zone for the **DNS suffix** and add a wildcard A record that points to the PSC endpoint IP address. Use the **Private endpoint** hostname and port in your connection strings and client applications.
+
+For more information, see [PrivateLink overview](/cloud/privatelink-overview).
+
+</Tab>
+</Tabs>
 
 ### Egress public IPs
 
@@ -77,20 +116,18 @@ The public IP addresses from which outbound traffic from this project originates
 
 ## Cloud metadata by platform
 
-| Metadata field | AWS | GCP | Azure |
-|:---------------|:----|:----|:------|
-| Workload Identity (IAM Role ARN) | ✅  | ✅ (service account email) | ✅ (managed identity resource ID) |
-| PrivateLink Principal | ✅ (AWS account ARN) | ✅ (GCP project number) | ✅ (Azure subscription ID) |
-| Serving PrivateLink — Endpoint Service Name | ✅  | ❌ | ❌ |
-| Serving PrivateLink — Private Endpoint | ✅  | ❌ | ❌ |
-| Egress public IPs | ✅  | ✅  | ✅    |
-
-<Note>
-GCP and Azure metadata field names differ from the AWS equivalents. The Console labels each field for the platform of your project. Serving PrivateLink is currently only available on AWS.
-</Note>
+| Metadata | AWS field | GCP field |
+|:---------|:----------|:----------|
+| Workload identity | Workload Identity (IAM Role ARN) | Workload Identity (GSA) |
+| Private connection identity | PrivateLink principals | PSC project |
+| Serving private connection | Serving PrivateLink | Serving Private Service Connect |
+| Service target | Endpoint service name | Service attachment URI |
+| DNS metadata | — | DNS suffix |
+| Connection endpoint | Private endpoint (`host:port`) | Private endpoint (`host:port`) |
+| Outbound addresses | Egress public IPs | Egress public IPs |
 
 ## Next steps
 
 - [Set up IAM role assume](/cloud/iam-role-assume) — use the IAM role ARN to grant RisingWave Cloud cross-account S3 access.
-- [Configure PrivateLink](/cloud/create-a-connection) — use the PrivateLink Principal when setting up your endpoint service's allowed principals.
+- [Configure PrivateLink](/cloud/create-a-connection) — use the PrivateLink principals when setting up your endpoint service's allowed principals.
 - [PrivateLink overview](/cloud/privatelink-overview) — learn how RisingWave Cloud uses PrivateLink for private connectivity between your VPC and RisingWave Cloud.

--- a/cloud/create-a-connection.mdx
+++ b/cloud/create-a-connection.mdx
@@ -30,7 +30,7 @@ You need to set up a PrivateLink service in your VPC and make sure it runs prope
 
 ## Create PrivateLink connection
 
-1. In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Connection** in the left sidebar.
+1. In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Network Access** in the left sidebar.
 2. Select the **PrivateLink** tab, and click **Create PrivateLink**.
 3. For **Name**, enter a descriptive name for the connection.
 4. For **Endpoint service name** or **Service attachment** or **Private link service resource ID:**
@@ -85,5 +85,5 @@ For details on how to use the VPC endpoint to create a source with the PrivateLi
 
 When you no longer need a connection:
 
-1. In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Connection** in the left sidebar. Select the **PrivateLink** tab.
+1. In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Network Access** in the left sidebar. Select the **PrivateLink** tab.
 2. Hover over the connection you want to drop and click the delete button, then confirm the deletion.

--- a/cloud/privatelink-overview.mdx
+++ b/cloud/privatelink-overview.mdx
@@ -31,23 +31,25 @@ On the **RisingWave Cloud** side, RisingWave Cloud will create an endpoint (spec
 
 On the **Customer** side, you need to set up a PrivateLink service (specifically an AWS endpoint service, GCP published service, or Azure Private Link service) in your VPC network first.
 
-## Serving PrivateLink (connect to RisingWave Cloud from your VPC)
+## Serving PrivateLink and Private Service Connect (connect to RisingWave Cloud from your VPC)
 
-In addition to connecting RisingWave Cloud to services in your VPC, RisingWave Cloud also supports **Serving PrivateLink** — currently available only for AWS — a reverse path that lets you connect *to* RisingWave Cloud privately from your own AWS VPC.
+In addition to connecting RisingWave Cloud to services in your VPC, RisingWave Cloud also supports a reverse path that lets you connect *to* RisingWave Cloud privately. This feature is called **Serving PrivateLink** on AWS and **Serving Private Service Connect** on GCP.
 
-On AWS, With Serving PrivateLink, RisingWave Cloud creates an AWS endpoint service. You then create an [Interface VPC Endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html) in your AWS account to connect to it. All traffic between your VPC and RisingWave Cloud stays on the AWS internal network.
+On AWS, with Serving PrivateLink, RisingWave Cloud creates an AWS endpoint service. You then create an [Interface VPC Endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html) in your AWS account to connect to it. All traffic between your VPC and RisingWave Cloud stays on the AWS internal network.
 
-The **Serving PrivateLink** section on the **Cloud Meta** tab (in **Connection** → **Cloud Meta**) exposes two fields:
+On GCP, with Serving Private Service Connect, RisingWave Cloud publishes a service attachment. You create a Private Service Connect endpoint that targets the service attachment and configure private DNS for the endpoint.
 
-- **Endpoint Service Name** — the name of the AWS endpoint service created by RisingWave Cloud. Use this value when creating an Interface VPC Endpoint in your own AWS account.
-- **Private Endpoint** — the hostname to use in your connection strings once the Interface VPC Endpoint is available.
+The **Cloud Meta** tab (in **Network Access** → **Cloud Meta**) exposes the provider-specific connection values:
 
-See [Cloud metadata](/cloud/cloud-metadata#serving-privatelink) for step-by-step instructions on using these fields.
+- For AWS, **Endpoint Service Name** and **Private Endpoint** (`host:port`).
+- For GCP, **Service attachment URI**, **DNS suffix**, and **Private endpoint** (`host:port`).
+
+See [Cloud metadata](/cloud/cloud-metadata) for instructions on using these fields.
 
 ## Accessing PrivateLink in the Console
 
-In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Connection** in the left sidebar. Then select the **PrivateLink** tab to create and manage PrivateLink connections.
+In the [RisingWave Cloud Console](https://cloud.risingwave.com), go to your project and click **Network Access** in the left sidebar. Then select the **PrivateLink** tab to create and manage PrivateLink connections.
 
 <Tip>
-When setting up an AWS endpoint service, add the **PrivateLink Principal** from your project's **Cloud Meta** tab ([Cloud metadata](/cloud/cloud-metadata)) to the service's allowed principals list so that RisingWave Cloud can connect.
+When setting up an AWS endpoint service, add the **PrivateLink principals** from your project's **Cloud Meta** tab ([Cloud metadata](/cloud/cloud-metadata)) to the service's allowed principals list so that RisingWave Cloud can connect.
 </Tip>


### PR DESCRIPTION
## Summary

- Document Cloud Meta fields separately for AWS and GCP.
- Add GCP workload identity, PSC project, and Serving Private Service Connect values.
- Align the support matrix and related PrivateLink overview with the current AWS/GCP UI, including plural PrivateLink principals and private endpoints in `host:port` form.

## Why

The existing Cloud metadata page was AWS-centric, listed Azure as supported, and omitted the GCP fields exposed by the Cloud UI and API. RisingWave Cloud PR [#14754](https://github.com/risingwavelabs/risingwave-cloud/pull/14754) added GCP Serving PSC metadata and identified customer documentation as a follow-up.

## User impact

AWS and GCP users can now map each value shown in **Network Access → Cloud Meta** to the corresponding identity or private-connectivity setup step.

## Validation

- `git diff --check`
- `npx --yes mintlify broken-links`
