### PR TITLE
fix: gate and verify Copilot issue assignment

### DIFF
--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -2,7 +2,9 @@ name: Auto-assign Issues to Copilot
 
 on:
   issues:
-    types: [opened, reopened]
+    # A newly created issue with labels emits `labeled` events in addition to
+    # `opened`, so omit `opened` to avoid assigning Copilot twice.
+    types: [reopened, labeled]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -15,6 +17,14 @@ permissions:
 
 jobs:
   assign-issue:
+    # `docs-agent` is an explicit opt-in. Other documentation issues may be
+    # handled by Jarvis, humans, or serve only as umbrella/tracking issues.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' &&
+        contains(github.event.issue.labels.*.name, 'docs-agent') &&
+        (github.event.action == 'reopened' ||
+          github.event.label.name == 'docs-agent'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/auto-assign-issues-to-copilot.yml
+++ b/.github/workflows/auto-assign-issues-to-copilot.yml
@@ -13,7 +13,7 @@ on:
         type: number
 
 permissions:
-  issues: write
+  contents: read
 
 jobs:
   assign-issue:
@@ -28,13 +28,55 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate GitHub App secrets
+        env:
+          APP_ID: ${{ secrets.COPILOT_APP_ID }}
+          APP_KEY: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$APP_ID" ] || [ -z "$APP_KEY" ]; then
+            echo "::error::Missing required secrets: COPILOT_APP_ID and/or COPILOT_APP_PRIVATE_KEY"
+            exit 1
+          fi
+
+      - name: Generate GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.COPILOT_APP_ID }}
+          private-key: ${{ secrets.COPILOT_APP_PRIVATE_KEY }}
+
       - name: Assign issue to Copilot
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event_name == 'issues' && github.event.issue.number || github.event.inputs.issue_number }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          gh api \
-            -X POST \
+          set -euo pipefail
+
+          body=$(jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BASE_BRANCH" \
+            '{
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $repo,
+                base_branch: $branch,
+                custom_instructions: "",
+                custom_agent: "",
+                model: ""
+              }
+            }')
+
+          response=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             "repos/$REPO/issues/$ISSUE_NUMBER/assignees" \
-            --field 'assignees[]=Copilot'
+            --input - <<< "$body")
+
+          if ! jq -e 'any(.assignees[]?; .login == "copilot-swe-agent[bot]" or .login == "copilot-swe-agent")' \
+            <<< "$response" >/dev/null; then
+            echo "::error::GitHub accepted the request but did not assign Copilot to issue #$ISSUE_NUMBER"
+            exit 1
+          fi

--- a/get-started/rw-benchmarks-stream-processing.mdx
+++ b/get-started/rw-benchmarks-stream-processing.mdx
@@ -96,7 +96,7 @@ For a broader comparison that covers architectural differences, feature sets, an
 - Dynamic filtering operations
 - Aggregations with large state management
 
-#### Comparable performance (90-110% of Flink)
+#### Comparable performance (90–110 percent of Flink)
 - Basic stateless computations
 - Simple filtering operations
 - Network I/O bound operations


### PR DESCRIPTION
## Description

Make Copilot issue assignment explicit and verifiable instead of running for every newly opened documentation issue and silently accepting a no-op API response.

- Assign Copilot only when the `docs-agent` label is added.
- Reassign on reopen only when the issue is still opted in with `docs-agent`.
- Preserve `workflow_dispatch` as a manual override.
- Omit the `opened` activity to avoid duplicate `opened` and `labeled` workflow runs when an issue is created with labels.
- Use the official `copilot-swe-agent[bot]` REST payload with `agent_assignment` metadata.
- Authenticate through the repository's existing Copilot GitHub App secrets.
- Fail the workflow unless the API response confirms that Copilot is actually assigned.
- Fix the pre-existing malformed benchmark heading URI that blocked the repository-wide broken-links check.

## Root cause

The previous workflow sent `assignees[]=Copilot` with `GITHUB_TOKEN`. GitHub returned HTTP 201 but silently ignored the invalid/unassignable assignee, leaving the response's `assignees` array empty. This made the workflow appear successful even though Copilot never received the issue. Issue #1423 demonstrates this: only Patrick was assigned by Jarvis, and PR #1424 was authored by `rw-jarvis-bot`, not Copilot.

The broken-links CI failure was unrelated to the workflow diff: a `%` in the `Comparable performance (90-110% of Flink)` heading produced a malformed auto-generated URI. The heading now spells out `percent`.

## Related code PR

- risingwavelabs/jarvis-v2#491 fixes the separate Jarvis eligibility and retry races.

## Related doc issue

- #1423 exposed both the unconditional trigger and the false-success assignment.

## Validation

- `yq eval` YAML parsing
- `git diff --check`
- `actionlint v1.7.7`
- `npx --yes mintlify@latest broken-links`
- confirmed `COPILOT_APP_ID` and `COPILOT_APP_PRIVATE_KEY` are configured for the repository

## Checklist

- [x] The workflow YAML and GitHub Actions expression syntax have been validated.
- [x] The repository-wide Mintlify broken-links check passes locally.
- [x] No new documentation page or navigation entry is added.
