### PR TITLE
docs: close v3.0.2 permanent documentation gaps

### DIFF
--- a/ingestion/sources/mysql/mysql-cdc.mdx
+++ b/ingestion/sources/mysql/mysql-cdc.mdx
@@ -95,6 +95,10 @@ FROM mysql_db TABLE 'public.large_table';
 
 [Debezium v2.6 connector configuration properties](https://debezium.io/documentation/reference/2.6/connectors/mysql.html#mysql-advanced-connector-configuration-properties) can also be specified under the `WITH` clause when creating a table or shared source. Add the prefix `debezium.` to the connector property you want to include.
 
+If `debezium.time.precision.mode` is not specified, RisingWave uses
+`microseconds`. Set it to `connect` only when the upstream temporal values use
+millisecond precision.
+
 For instance, to skip unknown DDL statements, specify the `schema.history.internal.skip.unparseable.ddl` parameter as `debezium.schema.history.internal.skip.unparseable.ddl`.
 
 ```sql

--- a/ingestion/sources/mysql/self-hosted.mdx
+++ b/ingestion/sources/mysql/self-hosted.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Set up a self-hosted PostgreSQL database"
+title: "Set up a self-hosted MySQL database"
 sidebarTitle: "Self-hosted"
 description: "How to set up a self-hosted MySQL database as a source for RisingWave."
 ---

--- a/ingestion/sources/mysql/self-hosted.mdx
+++ b/ingestion/sources/mysql/self-hosted.mdx
@@ -19,6 +19,15 @@ CREATE USER 'user'@'%' IDENTIFIED BY 'password';
 GRANT SELECT, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user'@'%';
 ```
 
+For MariaDB 10.5 and later, `BINLOG MONITOR` is the renamed equivalent of
+`REPLICATION CLIENT`. You can grant it instead:
+
+```sql
+GRANT SELECT, REPLICATION SLAVE, BINLOG MONITOR ON *.* TO 'user'@'%';
+```
+
+RisingWave accepts either privilege when validating a MariaDB CDC source.
+
 3. Finalize the privileges.
 
 ```sql

--- a/ingestion/sources/postgresql/pg-cdc.mdx
+++ b/ingestion/sources/postgresql/pg-cdc.mdx
@@ -366,7 +366,7 @@ supported by this mapping.
 
 To enable this feature, set `auto.schema.change = 'true'` in your PostgreSQL CDC source configuration:
 
-```SQL
+```sql
 CREATE SOURCE pg_source WITH (
  connector = 'postgres-cdc',
  hostname = 'localhost',
@@ -381,7 +381,7 @@ CREATE SOURCE pg_source WITH (
 
 Create a RisingWave table from the PostgreSQL source:
 
-```SQL
+```sql
 CREATE TABLE my_table (
     id INT PRIMARY KEY,
     name VARCHAR

--- a/ingestion/sources/postgresql/pg-cdc.mdx
+++ b/ingestion/sources/postgresql/pg-cdc.mdx
@@ -128,6 +128,10 @@ FROM pg_mydb TABLE 'public.large_table';
 
 You can also specify any valid [Debezium PostgreSQL connector configuration property](https://debezium.io/documentation/reference/2.6/connectors/postgresql.html#postgresql-advanced-configuration-properties) in the `WITH` clause. Prefix the Debezium parameter name with `debezium.`.
 
+If `debezium.time.precision.mode` is not specified, RisingWave uses
+`microseconds`. Set it to `connect` only when the upstream temporal values use
+millisecond precision.
+
 For example, to skip unknown DDL statements, use:
 
 ```sql
@@ -355,6 +359,10 @@ Currently, RisingWave supports the `ALTER TABLE` command with the following oper
 
 * `ADD COLUMN [DEFAULT expr]`: Allows you to add a new column to an existing table. Only constant value expressions are supported for the default value.
 * `DROP COLUMN`: Allows you to remove an existing column from a table.
+
+During automatic schema changes, RisingWave maps PostgreSQL enum arrays, such
+as `mood_enum[]`, to `varchar[]`. Arrays of PostgreSQL composite types are not
+supported by this mapping.
 
 To enable this feature, set `auto.schema.change = 'true'` in your PostgreSQL CDC source configuration:
 

--- a/ingestion/sources/sql-server-cdc.mdx
+++ b/ingestion/sources/sql-server-cdc.mdx
@@ -132,6 +132,10 @@ SELECT * FROM t2 ORDER BY v1;
 
 [Debezium v2.6 connector configuration properties](https://debezium.io/documentation/reference/2.6/connectors/sqlserver.html#sqlserver-advanced-connector-configuration-properties) can also be specified under the `WITH` clause when creating a table or shared source. Add the prefix `debezium.` to the connector property you want to include.
 
+If `debezium.time.precision.mode` is not specified, RisingWave uses
+`microseconds`. Set it to `connect` only when the upstream temporal values use
+millisecond precision.
+
 For instance, to skip unknown DDL statements, specify the `schema.history.internal.skip.unparseable.ddl` parameter as `debezium.schema.history.internal.skip.unparseable.ddl`.
 
 ```sql

--- a/integrations/destinations/amazon-dynamodb.mdx
+++ b/integrations/destinations/amazon-dynamodb.mdx
@@ -42,6 +42,12 @@ FORMAT data_format ENCODE data_encode [ (
 | aws.profile                         | **Optional**. The name of the AWS CLI profile to use for accessing DynamoDB. If specified, it overrides the default profile.                                         |
 | dynamodb.max\_batch\_item\_nums  | **Optional**. The maximum number of items in the [`BatchWriteItem`](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html) operation. It must be larger than 1, and less than or equal to 25. The default is 25.                           |
 | dynamodb.max\_future\_send\_nums   | **Optional**. The maximum number of concurrent write futures in DynamoDB. It must be less than 360, and the default is 256. This is derived from user-defined `max_parallelism_units` (40000 by default). If the write throughput of RisingWave exceeds the `max_parallelism_units` set in DynamoDB, an error would be reported.                              |
+| dynamodb.batch\_write\_retry\_times | **Optional**. The maximum number of times to retry items returned by DynamoDB as unprocessed. The default is 3. |
+| dynamodb.batch\_write\_retry\_backoff\_ms | **Optional**. The initial retry backoff in milliseconds for unprocessed items. The backoff increases exponentially, includes jitter, and is capped at 2 seconds. The default is 100. |
+
+When a `BatchWriteItem` request succeeds but returns unprocessed items,
+RisingWave retries only those items. If the configured retries are exhausted,
+the sink reports an error so that its normal recovery process can take over.
 
 ## Partition key and sort key mapping
 

--- a/sql/functions/ai.mdx
+++ b/sql/functions/ai.mdx
@@ -23,10 +23,33 @@ The `config` parameter is a JSONB object that supports the following options:
 | `model` | Yes | The embedding model to use (e.g., `text-embedding-3-small`) |
 | `api_key` | No | OpenAI API key |
 | `org_id` | No | OpenAI organization ID |
-| `proj_id` | No | OpenAI project ID |
+| `project_id` | No | OpenAI project ID |
 | `api_base` | No | Custom API base URL. Default: `https://api.openai.com/v1` |
 
 ```sql Example
 openai_embedding('{"model": "text-embedding-3-small", "api_key": "sk-proj-1234567890"}'::jsonb, 'Hello, world!') -> {0.0001, 0.0002, 0.0003, ...}
 ```
 
+#### Retry behavior
+
+If an OpenAI embedding request fails, RisingWave retries it with exponential
+backoff. The delay starts at 100 milliseconds and is capped at 10 seconds.
+Retries continue until the request returns a valid embedding response.
+
+#### Metrics
+
+RisingWave exposes the following Prometheus metrics for `openai_embedding`.
+Each metric has `model` and `api_base` labels.
+
+| Metric | Description |
+| :----- | :---------- |
+| `openai_embedding_success_count` | Total number of successful embedding requests. |
+| `openai_embedding_failure_count` | Total number of failed request attempts. Retries are counted as separate failed attempts. |
+| `openai_embedding_latency` | Latency in seconds for successful request attempts. |
+| `openai_embedding_input_rows` | Total number of non-null, non-empty input rows submitted for embedding. |
+| `openai_embedding_input_row_word_count` | Distribution of word counts for non-null, non-empty input rows. |
+| `openai_embedding_inflight_requests` | Number of embedding requests currently in flight. |
+| `openai_embedding_inflight_rows` | Number of input rows in in-flight embedding requests. |
+
+For information about accessing Prometheus metrics, see
+[Prometheus metrics reference](/operate/prometheus-metrics-reference).

--- a/sql/functions/ai.mdx
+++ b/sql/functions/ai.mdx
@@ -34,7 +34,8 @@ openai_embedding('{"model": "text-embedding-3-small", "api_key": "sk-proj-123456
 
 If an OpenAI embedding request fails, RisingWave retries it with exponential
 backoff. The delay starts at 100 milliseconds and is capped at 10 seconds.
-Retries continue until the request returns a valid embedding response.
+There is no built-in retry limit. If OpenAI continues returning errors,
+RisingWave continues retrying until it receives a valid embedding response.
 
 #### Metrics
 


### PR DESCRIPTION
## Summary

- document MariaDB `BINLOG MONITOR` privileges for CDC validation
- document the `microseconds` default for `debezium.time.precision.mode` across MySQL, PostgreSQL, and SQL Server CDC
- document PostgreSQL enum-array mapping during automatic schema changes
- document DynamoDB unprocessed-item retry controls and recovery behavior
- document `openai_embedding` retry behavior and Prometheus metrics
- correct the OpenAI embedding config key from `proj_id` to `project_id`

## Evidence

Verified against the final `release-3.0` implementation and the corresponding source PRs:

- risingwavelabs/risingwave#26234 — MariaDB CDC validation
- risingwavelabs/risingwave#26035 — CDC time precision default
- risingwavelabs/risingwave#25959 — PostgreSQL enum arrays during auto schema change
- risingwavelabs/risingwave#25985 — DynamoDB unprocessed-item retries
- risingwavelabs/risingwave#26001 — OpenAI embedding retry and metrics

The OpenAI metric labels were checked against `src/expr/impl/src/scalar/ai_model.rs`; the implementation uses both `model` and `api_base`. DynamoDB option names, defaults, exponential backoff, jitter, and the 2-second cap were checked against `src/connector/src/sink/dynamodb.rs` on `release-3.0`.

Addresses the permanent-documentation items tracked in #1423. It intentionally does not document the `streaming.developer` projection-concurrency settings because their public/internal status still needs an explicit owner decision.

## Validation

- `git diff --check`
- `typos --config ./typos.toml <changed files>`
- `npx --yes mintlify broken-links`

Runtime verification was not performed because the changes cover infrastructure-dependent CDC connectors, DynamoDB, and the external OpenAI API.
