### PR TITLE
docs: fix remaining v3.0.2 documentation gaps

### DIFF
--- a/changelog/release-notes.mdx
+++ b/changelog/release-notes.mdx
@@ -16,7 +16,7 @@ description: This page summarizes changes in each version of RisingWave, includi
 
 ## Optimizer
 
-- Improves streaming project performance by evaluating chunks concurrently. [#26000](https://github.com/risingwavelabs/risingwave/pull/26000)
+- Allows streaming project chunks to be evaluated concurrently when configured; the default remains sequential. [#26000](https://github.com/risingwavelabs/risingwave/pull/26000)
 - Fixes ASOF left join predicate semantics, mirrored Iceberg comparison boundaries, large parameterized `IN` lists, invalid index lookup selection, and planning of impure project expressions. [#26198](https://github.com/risingwavelabs/risingwave/pull/26198), [#26195](https://github.com/risingwavelabs/risingwave/pull/26195), [#26310](https://github.com/risingwavelabs/risingwave/pull/26310), [#26287](https://github.com/risingwavelabs/risingwave/pull/26287), [#26024](https://github.com/risingwavelabs/risingwave/pull/26024)
 - Corrects stream table scan and materialized view primary-key derivation. [#25783](https://github.com/risingwavelabs/risingwave/pull/25783), [#25804](https://github.com/risingwavelabs/risingwave/pull/25804)
 

--- a/sql/commands/sql-alter-source.mdx
+++ b/sql/commands/sql-alter-source.mdx
@@ -62,10 +62,13 @@ The following connectors and properties are currently supported:
 | Connector | Alterable properties |
 | :-------- | :------------------- |
 | Kafka (`kafka`) | `properties.client.id`, `properties.sync.call.timeout`, `properties.enable.auto.commit`, `properties.auto.commit.interval.ms`, `properties.enable.ssl.certificate.verification`, `properties.fetch.max.bytes`, `properties.fetch.queue.backoff.ms`, `properties.fetch.wait.max.ms`, `properties.message.max.bytes`, `properties.queued.max.messages.kbytes`, `properties.queued.min.messages`, `properties.receive.message.max.bytes`, `properties.reconnect.backoff.ms`, `properties.reconnect.backoff.max.ms`, `properties.retry.backoff.ms`, `properties.retry.backoff.max.ms`, `properties.socket.connection.setup.timeout.ms`, `properties.statistics.interval.ms`, `properties.ssl.endpoint.identification.algorithm`, `properties.security.protocol`, `properties.sasl.mechanism`, `properties.sasl.username`, `properties.sasl.password` |
-| PostgreSQL CDC (`postgres-cdc`), MySQL CDC (`mysql-cdc`), SQL Server CDC (`sqlserver-cdc`), MongoDB CDC (`mongodb-cdc`) | `cdc.source.wait.streaming.start.timeout`, `debezium.max.queue.size`, `debezium.queue.memory.ratio` |
+| MySQL CDC (`mysql-cdc`) | `cdc.source.wait.streaming.start.timeout`, `debezium.max.queue.size`, `debezium.queue.memory.ratio`, `hostname`, `port`, `password` |
+| PostgreSQL CDC (`postgres-cdc`) | `cdc.source.wait.streaming.start.timeout`, `debezium.max.queue.size`, `debezium.queue.memory.ratio`, `debezium.heartbeat.interval.ms`, `hostname`, `port`, `password` |
+| SQL Server CDC (`sqlserver-cdc`) | `cdc.source.wait.streaming.start.timeout`, `debezium.max.queue.size`, `debezium.queue.memory.ratio`, `hostname`, `port`, `password` |
+| MongoDB CDC (`mongodb-cdc`) | `cdc.source.wait.streaming.start.timeout`, `debezium.max.queue.size`, `debezium.queue.memory.ratio` |
 
 <Note>
-For CDC connectors, only the Debezium runtime tunables above can be altered in place. Connection-level fields such as `hostname`, `port`, `database.name`, `username`, and `password` still require recreating the source. To rotate credentials without changing the SQL definition, store them in a [secret](/sql/commands/sql-create-secret) and update the secret with [`ALTER SECRET`](/sql/commands/sql-alter-secret) — note that running CDC jobs only pick up the new value after a restart.
+Starting in v3.0.2, MySQL, PostgreSQL, and SQL Server CDC sources can update `hostname`, `port`, and `password` in place. Other connection-level fields, such as `database.name` and `username`, still require recreating the source. To rotate credentials without changing the SQL definition, store them in a [secret](/sql/commands/sql-create-secret) and update the secret with [`ALTER SECRET`](/sql/commands/sql-alter-secret) — note that running CDC jobs only pick up the new value after a restart.
 </Note>
 
 ```sql Example: Kafka
@@ -80,6 +83,14 @@ CONNECTOR WITH (
 ALTER SOURCE pg_cdc_source
 CONNECTOR WITH (
   'debezium.max.queue.size' = '16384'
+);
+```
+
+```sql Example: Update a PostgreSQL CDC endpoint
+ALTER SOURCE pg_cdc_source
+CONNECTOR WITH (
+  'hostname' = 'new-private-host',
+  'port' = '5432'
 );
 ```
 


### PR DESCRIPTION
## Summary

- align the `ALTER SOURCE ... CONNECTOR WITH` CDC property table with the RisingWave v3.0.2 and current `main` allowlists
- document that MySQL, PostgreSQL, and SQL Server CDC sources can update `hostname`, `port`, and `password` in place starting in v3.0.2
- add a PostgreSQL CDC endpoint-update example
- clarify that concurrent streaming project evaluation is opt-in and remains sequential by default

## Evidence

- RisingWave PR #26019 adds `hostname` and `port` to the MySQL, PostgreSQL, and SQL Server CDC alter-on-fly allowlists; `password` is also present in those allowlists
- `src/connector/src/allow_alter_on_fly_fields.rs` at both tag `v3.0.2` and current `main` confirms the connector-specific property sets documented here
- RisingWave PR #26000 defines `streaming.developer.project_expr_concurrency = 1` by default, preserving sequential evaluation unless concurrency is configured
- the v3.0.2 metadata-cleanup fix from RisingWave PR #26413 is already covered by merged docs PR #1449, so this PR does not duplicate it

## Validation

- `git diff --check`
- `typos --config ./typos.toml changelog/release-notes.mdx sql/commands/sql-alter-source.mdx`
- `npx -y mint@latest broken-links`

Refs #1423
