### PR TITLE
Add SeaweedFS catalog page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -662,6 +662,7 @@
                       "iceberg/catalogs/jdbc",
                       "iceberg/catalogs/rest",
                       "iceberg/catalogs/lakekeeper",
+                      "iceberg/catalogs/seaweedfs",
                       "iceberg/catalogs/hive",
                       "iceberg/catalogs/snowflake",
                       "iceberg/catalogs/unity"

--- a/iceberg/catalogs.mdx
+++ b/iceberg/catalogs.mdx
@@ -39,6 +39,9 @@ External catalogs are required when you need to connect to Iceberg tables that a
   <Card title="Amazon S3 Tables" href="/iceberg/catalogs/s3-tables">
     An AWS-native REST-based catalog with SigV4 authentication.
   </Card>
+  <Card title="SeaweedFS" href="/iceberg/catalogs/seaweedfs">
+    A self-hosted REST catalog and Parquet storage in one SeaweedFS S3 gateway.
+  </Card>
   <Card title="Hive Metastore" href="/iceberg/catalogs/hive">
     Stores metadata using a Hive Metastore backend.
   </Card>

--- a/iceberg/catalogs/seaweedfs.mdx
+++ b/iceberg/catalogs/seaweedfs.mdx
@@ -1,0 +1,105 @@
+---
+title: "SeaweedFS catalog"
+sidebarTitle: "SeaweedFS"
+description: "Connect RisingWave to SeaweedFS table buckets, which serve an Iceberg REST catalog and store table data behind one S3 gateway."
+---
+
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) is an open-source distributed object store whose S3 Table Buckets provide both halves of an Iceberg deployment: the embedded Iceberg REST catalog serves the table metadata, and the table bucket stores the table data as Parquet files behind the same S3 gateway. You can use it with RisingWave when creating an Iceberg `SOURCE` or `SINK`.
+
+<Note>
+For a complete list of all catalog-related parameters, see the main [Catalog configuration](/iceberg/catalogs#catalog-parameters) page.
+</Note>
+
+## Deploy SeaweedFS
+
+For local testing, create a file `s3config.json` with the S3 credentials:
+
+```json
+{
+  "identities": [
+    {
+      "name": "analyst",
+      "credentials": [
+        {
+          "accessKey": "your_access_key",
+          "secretKey": "your_secret_key"
+        }
+      ],
+      "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+    }
+  ]
+}
+```
+
+Then start the whole SeaweedFS stack in one container. The `-tableBucket` flag pre-creates a table bucket named `analytics` that serves as the Iceberg warehouse:
+
+```bash
+docker run -d --name seaweedfs -p 8333:8333 -p 8181:8181 \
+    -v "$(pwd)/s3config.json:/etc/seaweedfs/s3config.json" \
+    chrislusf/seaweedfs:latest \
+    mini -dir=/data -s3.config=/etc/seaweedfs/s3config.json -tableBucket=analytics
+```
+
+The S3 endpoint listens on port 8333 and the Iceberg REST catalog on port 8181.
+
+## Required REST parameters
+
+SeaweedFS authenticates catalog requests with AWS SigV4 signing, using the same access key and secret key as the S3 gateway:
+
+| Parameter | Description | Value for SeaweedFS |
+|---|---|---|
+| `catalog.uri` | The SeaweedFS Iceberg REST endpoint. | `http://<seaweedfs-host>:8181` |
+| `catalog.rest.sigv4_enabled` | Enables SigV4 signing. Must be `true`. | `true` |
+| `catalog.rest.signing_region` | The region for signing requests. | e.g., `us-east-1` |
+| `catalog.rest.signing_name` | The service name for signing requests. | `s3` |
+
+## Read from an Iceberg table
+
+```sql
+CREATE SOURCE seaweedfs_orders WITH (
+    connector = 'iceberg',
+    catalog.type = 'rest',
+    catalog.uri = 'http://<seaweedfs-host>:8181',
+    catalog.name = 'default',
+    database.name = 'default',
+    table.name = 'orders',
+    warehouse.path = 's3://analytics',
+    s3.endpoint = 'http://<seaweedfs-host>:8333',
+    s3.region = 'us-east-1',
+    s3.access.key = '<your_access_key>',
+    s3.secret.key = '<your_secret_key>',
+    s3.path.style.access = 'true',
+    catalog.rest.sigv4_enabled = 'true',
+    catalog.rest.signing_region = 'us-east-1',
+    catalog.rest.signing_name = 's3'
+);
+
+SELECT * FROM seaweedfs_orders;
+```
+
+## Write to an Iceberg table
+
+```sql
+CREATE SINK seaweedfs_sink FROM my_table
+WITH (
+    connector = 'iceberg',
+    catalog.type = 'rest',
+    catalog.uri = 'http://<seaweedfs-host>:8181',
+    catalog.name = 'default',
+    database.name = 'default',
+    table.name = 'orders',
+    warehouse.path = 's3://analytics',
+    s3.endpoint = 'http://<seaweedfs-host>:8333',
+    s3.region = 'us-east-1',
+    s3.access.key = '<your_access_key>',
+    s3.secret.key = '<your_secret_key>',
+    s3.path.style.access = 'true',
+    catalog.rest.sigv4_enabled = 'true',
+    catalog.rest.signing_region = 'us-east-1',
+    catalog.rest.signing_name = 's3',
+    type = 'append-only',
+    force_append_only = 'true'
+);
+```
+
+Rows are committed to the Iceberg table on RisingWave checkpoints, and other engines can read them through the same catalog.

--- a/iceberg/object-storage.mdx
+++ b/iceberg/object-storage.mdx
@@ -8,7 +8,7 @@ This guide provides the configuration parameters for connecting RisingWave to th
 
 ## S3-compatible storage
 
-These parameters configure the connection to an S3-compatible storage system, such as AWS S3 or MinIO, where your Iceberg data files are stored.
+These parameters configure the connection to an S3-compatible storage system, such as AWS S3, MinIO, or SeaweedFS, where your Iceberg data files are stored.
 
 | Parameter | Description |
 |---|---|
@@ -18,8 +18,8 @@ These parameters configure the connection to an S3-compatible storage system, su
 | `s3.secret.key` | **Required when `enable_config_load = false`**. The AWS secret access key. |
 | `s3.iam_role_arn` | **Optional**. The IAM role ARN to assume for S3 access via STS. Can be used with either `enable_config_load = false` or `true`. |
 | `enable_config_load` | **Optional**. If set to `true`, load AWS config/credentials from the environment (for example, to assume `s3.iam_role_arn`). When `enable_config_load = true`, do not provide `s3.access.key`/`s3.secret.key`. |
-| `s3.endpoint` | **Optional**. The endpoint for S3-compatible services like MinIO. For AWS S3, this is typically not needed. |
-| `s3.path.style.access` | **Optional**. Set to `true` to use path-style access (e.g., for MinIO). Defaults to `false` for virtual-hosted–style access. |
+| `s3.endpoint` | **Optional**. The endpoint for S3-compatible services like MinIO or SeaweedFS. For AWS S3, this is typically not needed. |
+| `s3.path.style.access` | **Optional**. Set to `true` to use path-style access (e.g., for MinIO or SeaweedFS). Defaults to `false` for virtual-hosted–style access. |
 
 <Note>
 In RisingWave Cloud, you have two options:


### PR DESCRIPTION
Adds a SeaweedFS catalog page under Iceberg catalogs, plus a card on the catalogs overview and SeaweedFS mentions in the S3-compatible object storage parameter notes.

SeaweedFS table buckets provide both halves of an Iceberg deployment: the embedded Iceberg REST catalog serves table metadata, and the table bucket stores the table data as Parquet files behind the same S3 gateway. The page covers a one-container deployment, the SigV4 REST parameters, and CREATE SOURCE / CREATE SINK examples.

Both examples are verified directly against risingwavelabs/risingwave:latest and the current SeaweedFS release with exactly the statements shown: the source reads a PyIceberg-seeded table, and the append-only sink's rows land in the Iceberg table and are read back through the catalog with PyIceberg. The same path runs as a CI suite in the SeaweedFS repository on every pull request: https://github.com/seaweedfs/seaweedfs/tree/master/test/s3tables/catalog_risingwave